### PR TITLE
Adding info about bolt uri

### DIFF
--- a/modules/ROOT/pages/addition/index.adoc
+++ b/modules/ROOT/pages/addition/index.adoc
@@ -166,7 +166,7 @@ Apart from the start configuration above, for each of the monitored DBMS instanc
 
 | `CONFIG_INSTANCE_n_BOLT_URI`
 | Bolt URI for nth instance
-| bolt://localhost:7687
+| bolt://localhost:7687 or bolt+s://localhost:7687 or bolt+ssc://localhost:7687, depending on the local database setup
 
 | `CONFIG_INSTANCE_n_BOLT_USERNAME`
 | Bolt user name for nth instance


### PR DESCRIPTION
Request:

For the [Adding a managed DBMS - Neo4j Ops manager](https://neo4j.com/docs/ops-manager/current/addition/#configure)(Agent configuration section) of the NOM documentation, would it be interesting/possible to add that the Bolt URI for nth instance could be bolt, bolt+s or bolt+ssc depending on the local database setup.