### PR TITLE
small fixes in the new agent installation docs

### DIFF
--- a/modules/ROOT/pages/addition/agent-installation/agent-config-file.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/agent-config-file.adoc
@@ -17,6 +17,7 @@ Recommended way to configure agent is through environment variables as specified
 ====
 
 Following is a minimal agent configuration that is persisted by agent for server connection:
+
 .nom-agent-config.yaml
 [source, yaml]
 ----

--- a/modules/ROOT/pages/addition/kubernetes/daemonset.adoc
+++ b/modules/ROOT/pages/addition/kubernetes/daemonset.adoc
@@ -10,6 +10,7 @@ that Neo4j pod uses. These need to be mounted to agent Daemon pod.
 ====
 
 . Following is a sample daemonset manifest for NOM agent:
+
 .daemonset.yaml
 [source, yaml]
 ----
@@ -53,6 +54,7 @@ spec:
 ----
 
 . A simple Neo4j instance deployed through helm charts;
+
 .values.yaml
 [source, yaml]
 ----
@@ -71,6 +73,7 @@ config:
 ----
 
 . A sample agent config to mount on agent Daemon pod from cluster node path (eg. `/deployments/daemonset`);
+
 .nom-agent-config.yaml
 [source, yaml]
 ----

--- a/modules/ROOT/pages/addition/kubernetes/in-container.adoc
+++ b/modules/ROOT/pages/addition/kubernetes/in-container.adoc
@@ -37,6 +37,7 @@ inject_agent $1 $2
 ----
 
 The above script requires the name of the Neo4j container running inside a pod and a `.env` style file with all the agent confiuration exported as shown below:
+
 .agent.env
 [source, shell]
 ----


### PR DESCRIPTION
insert new lines to fix headlines of example files (otherwise they were treated as text at the end of the previous passage)



----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [x ] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!