### PR TITLE
remove Neo4j namespaces setting (#109)

### DIFF
--- a/modules/ROOT/pages/addition/instance-requirements.adoc
+++ b/modules/ROOT/pages/addition/instance-requirements.adoc
@@ -47,8 +47,6 @@ For the metrics collection feature to work correctly. these configuration values
 
 ** `server.metrics.jmx.enabled=true`
 
-** `server.metrics.namespaces.enabled=true`
-
 == User privileges
 
 The agent logs on to the DBMS with the configured user to enable certain features such as viewing relationship and label types, managing privileges, and viewing configuration values.


### PR DESCRIPTION
this setting was removed in Neo4j 5 (see https://neo4j.com/docs/upgrade-migration-guide/current/version-5/migration/breaking-changes/#_metrics)



----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [ ] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!