### PR TITLE
remove dev from content branches

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -7,7 +7,7 @@ site:
 content:
   sources:
   - url: ./
-    branches: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', 'dev']
+    branches: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6']
     exclude:
     - '!**/_includes/*'
     - '!**/readme.adoc'


### PR DESCRIPTION

----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [ ] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!