### PR TITLE
Hints regarding finding server-logs.xml

### DIFF
--- a/modules/ROOT/pages/addition/agent-installation/manual.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/manual.adoc
@@ -330,7 +330,7 @@ The currently effective location of server log configuration can be found out us
 
 [source, terminal, role=noheader]
 ----
-./cypher-shell "CALL dbms.listConfig() YIELD name, value WHERE name CONTAINS 'server.logs.config' return value"
+./cypher-shell "CALL dbms.listConfig() YIELD name, value WHERE name='server.logs.config' RETURN value"
 ----
 
 [IMPORTANT]

--- a/modules/ROOT/pages/addition/agent-installation/manual.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/manual.adoc
@@ -162,7 +162,7 @@ The rest of NOM still works.
 | 9500
 
 | `CONFIG_INSTANCE_n_LOG_CONFIG_PATH`
-| Path to the instance log4j config. 
+| Path to the instance <<server_log_config,log4j config file>>.
 If set, appends the appropriate log appender automatically (including the port specified above).
 | /var/lib/neo4j/conf/server-logs.xml
 
@@ -320,6 +320,23 @@ agent service start
 ----
 agent service uninstall
 ----
+
+[[server_log_config]]
+=== Finding out the location of server log configuration (server-logs.xml)
+
+The location of server log configuration file is configured in `neo4j.conf` (see documentation on link:https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_server.logs.config[server.logs.config] configuration setting).
+
+The currently effective location of server log configuration can be found out using the following Cypher query:
+
+[source, terminal, role=noheader]
+----
+./cypher-shell "CALL dbms.listConfig() YIELD name, value WHERE name CONTAINS 'server.logs.config' return value"
+----
+
+[IMPORTANT]
+====
+Check that the server log configuration exists, otherwise NOM agent would not be able to add query log collection configuration to it.
+====
 
 [[verify]]
 == Verify agent setup

--- a/modules/ROOT/pages/addition/agent-installation/self-registered.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/self-registered.adoc
@@ -169,7 +169,7 @@ The rest of NOM still works.
 | 9500
 
 | `CONFIG_INSTANCE_n_LOG_CONFIG_PATH`
-| Path to the instance log4j config. 
+| Path to the instance xref:./manual.adoc#server_log_config[log4j config file].
 If set, appends the appropriate log appender automatically (including the port specified above).
 | /var/lib/neo4j/conf/server-logs.xml
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/QMQUcMEZ/1193-location-of-server-logsxml-is-incorrectly-configured-when-installing-via-rpm-package)

----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [X]  I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!