### PR TITLE
Document CONFIG_INSTANCE_n_QUERY_LOG_INCLUDE_AGENT

### DIFF
--- a/modules/ROOT/pages/addition/agent-installation/manual.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/manual.adoc
@@ -177,6 +177,10 @@ If set, appends the appropriate log appender automatically (including the port s
 | `CONFIG_INSTANCE_n_QUERY_LOG_DISABLE_OBFUSCATION`
 | Disable the string literal obfuscation in queries (optional)
 | true
+
+| `CONFIG_INSTANCE_n_QUERY_LOG_INCLUDE_AGENT`
+| Collect and show queries coming from the NOM agent (optional)
+| true
 |===
 
 [IMPORTANT]

--- a/modules/ROOT/pages/addition/agent-installation/self-registered.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/self-registered.adoc
@@ -184,6 +184,10 @@ If set, appends the appropriate log appender automatically (including the port s
 | `CONFIG_INSTANCE_n_QUERY_LOG_DISABLE_OBFUSCATION`
 | Disable the string literal obfuscation in queries (optional)
 | true
+
+| `CONFIG_INSTANCE_n_QUERY_LOG_INCLUDE_AGENT`
+| Collect and show queries coming from the NOM agent (optional)
+| true
 |===
 
 


### PR DESCRIPTION
Document new parameter that selects whether to include NOM queries in the query log analysis feature.

----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [x] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!