### PR TITLE
Certificate file names and minor fixes (#124)

### DIFF
--- a/modules/ROOT/pages/first-look/linux-first-look.adoc
+++ b/modules/ROOT/pages/first-look/linux-first-look.adoc
@@ -67,16 +67,16 @@ More information on Self Signed certificates *xref:installation/self-signed-cert
         --spring.neo4j.authentication.password=lovelypassword \
         --server.port=8080 \
         --server.ssl.key-store-type=PKCS12 \
-        --server.ssl.key-store=file:./certificates/localhost.pfx \
+        --server.ssl.key-store=file:./certificates/server.pfx \
         --server.ssl.key-store-password=<PASSWORD> \
         --grpc.server.port=9090 \
         --grpc.server.security.key-store-type=PKCS12 \
-        --grpc.server.security.key-store=file:./certificates/localhost.pfx\
+        --grpc.server.security.key-store=file:./certificates/server.pfx\
         --grpc.server.security.key-store-password=<PASSWORD>\
         --jwt.secret=please-set-a-random-secret-string-here-for-jwt-signing \
 ----
 
-Running as console application on Unix is documented *xref:installation/server.adoc#_unix[here]*
+Running as console application on Unix is documented *xref:installation/server.adoc#unix[here]*
 
 === Open NOM UI
 Wait for the server to start and then go to https://localhost:8080. 
@@ -87,7 +87,7 @@ Login as admin:passw0rd and accept license terms.
 In NOM UI - navigate to Agent settings (clicking on the sad robot takes you to the correct page) and add a new agent.
 Copy environment variables that are provided. 
 
-Full documentation on registering an agent is *xref:addition/index.adoc#register[here]*. 
+Full documentation on registering an agent is *xref:addition/agent-installation/index.adoc[here]*.
 
 === Unpack agent
 [source, terminal, role=noheader]
@@ -107,7 +107,7 @@ Edit the export command below as follows:
 ----
 export \
 <OUTPUT_FROM_REGISTER_AGENT>
-CONFIG_TLS_TRUSTED_CERTS=<SERVER_INSTALL_DIR>/certificates/localhost.cer \
+CONFIG_TLS_TRUSTED_CERTS=<SERVER_INSTALL_DIR>/certificates/server.cer \
 CONFIG_LOG_LEVEL=debug \
 CONFIG_INSTANCE_1_NAME=server1 \
 CONFIG_INSTANCE_1_BOLT_URI=<SERVER_1_BOLT_URI>  \
@@ -130,7 +130,7 @@ CONFIG_INSTANCE_3_LOG_CONFIG_PATH=<SERVER3_HOME_DIR>/conf/server-logs.xml
 ----
 Run the edited export command. 
 
-Full documentation on configuring an agent is *xref:addition/index.adoc#configure[here]*. 
+Full documentation on configuring an agent is *xref:addition/agent-installation/index.adoc[here]*.
 
 === Run agent as console application
 

--- a/modules/ROOT/pages/installation/self-signed-certificate.adoc
+++ b/modules/ROOT/pages/installation/self-signed-certificate.adoc
@@ -64,3 +64,8 @@ It generates a key pair and a self-signed certificate and creates `localhost.cer
 `localhost.pfx` is assigned the password `changeit` which is provided to the command as an argument.
 
 You can then use these two files to configure the server and agents for TLS encrypted communication.
+
+[IMPORTANT]
+====
+Please note that in the rest of documentation, certificate files are referred to as `server.cer` and `server.pfx`.
+====

--- a/modules/ROOT/pages/installation/server.adoc
+++ b/modules/ROOT/pages/installation/server.adoc
@@ -128,6 +128,7 @@ Although it is possible to run the NOM Server as a console application, it is no
 Best practice is to run the NOM Server as a service, as described in the previous section.
 ====
 
+[[unix]]
 === Unix
 ==== Passing arguments on command line
 
@@ -200,7 +201,7 @@ java -jar .\lib\server.jar
 
 [NOTE]
 ====
-If the NOM Server is required to support self-registered agents, then addtional configuration needs to be provided to above commands as mentioned in the configuration reference table. More about agent self-registration xref:../addition/agent-installation/self-registered.adoc[here]
+If the NOM Server is required to support self-registered agents, then additional configuration needs to be provided to above commands as mentioned in the configuration reference table. More about agent self-registration xref:../addition/agent-installation/self-registered.adoc[here]
 ====
 
 == Server configuration reference [[config_ref]]


### PR DESCRIPTION
* small fixes

* avoiding confusion with certificate names



----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [x] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!