### PR TITLE
Add a note for SELinux to change the SELinux context of the server an…

### DIFF
--- a/modules/ROOT/pages/addition/agent-installation/manual.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/manual.adoc
@@ -41,10 +41,23 @@ The following steps are required to install an agent:
 
 NOTE: If downloading agents is not a option in some environments, NOM agents are also bundled into Neo4j packages which can be used for the installation as described xref:./install-packaged.adoc[here]
 
-** Extract the archive:
+** Extract the archive
+
+** This step is only required if using *SELinux*.
+To permanently change the SELinux context of the agent binary, run the following commands:
++
+[source, terminal, role=noheader]
+----
+sudo semanage fcontext -a -t bin_t <EXTRACTED_DIRECTORY_PATH>/bin/agent
+sudo restorecon -v <EXTRACTED_DIRECTORY_PATH>/bin/agent
+----
++
+<EXTRACTED_DIRECTORY_PATH> should be replaced with the path to the extracted directory.
+
 
 ** Add the `bin` folder in the extracted directory to `PATH`
-* To verify the installation, run the following command:
+
+** To verify the installation, run the following command:
 +
 [source, terminal, role=noheader]
 ----

--- a/modules/ROOT/pages/addition/agent-installation/self-registered.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/self-registered.adoc
@@ -20,6 +20,17 @@ NOTE: If downloading agents is not an option in some environments, NOM agents ar
 
 ** Extract the archive:
 
+** This step is only required if using *SELinux*.
+To permanently change the SELinux context of the agent binary, run the following commands:
++
+[source, terminal, role=noheader]
+----
+sudo semanage fcontext -a -t bin_t <EXTRACTED_DIRECTORY_PATH>/bin/agent
+sudo restorecon -v <EXTRACTED_DIRECTORY_PATH>/bin/agent
+----
++
+<EXTRACTED_DIRECTORY_PATH> should be replaced with the path to the extracted directory.
+
 ** Add the `bin` folder in the extracted directory to `PATH`
 * To verify the installation, run the following command:
 +

--- a/modules/ROOT/pages/installation/server.adoc
+++ b/modules/ROOT/pages/installation/server.adoc
@@ -61,7 +61,7 @@ The table <<config_ref,here>> contains environment variables and example values.
 
 ==== Installation
 
-After updating the `neo4j-ops-manager-server.service` file to reflect your configuration, it must be copied into the directory `/etc/systemd/system`.
+Copy `neo4j-ops-manager-server.service` file into the directory `/etc/systemd/system`.
 
 Next, execute the following commands to install the NOM Server as a service:
 
@@ -73,7 +73,7 @@ sudo systemctl enable neo4j-ops-manager-server
 
 ==== Starting and stopping
 
-Once the installation is successfully completed, you can start the NOM Server as a service with the command:
+Start the NOM Server as a service with the command:
 
 [source, terminal, role=noheader]
 ----
@@ -89,6 +89,20 @@ To stop the NOM Server, use the command:
 sudo systemctl stop neo4j-ops-manager-server
 ----
 
+[NOTE]
+====
+*For SELinux*
+
+The SELinux context of the server binary must be changed so that it can be executed from the service. 
+To permanently change the SELinux context of the file, run the following commands:
+[source, terminal, role=noheader]
+----
+sudo semanage fcontext -a -t bin_t <SERVER_PATH>/bin/server
+sudo restorecon -v <SERVER_PATH>/bin/server
+----
+<SERVER_PATH> should be replaced with the path to the NOM server-folder.
+
+====
 
 === Windows
 ==== Setting arguments in the service file


### PR DESCRIPTION
…d agent binaries (#144)

* Add a note for SELinux to change the SELinux context of the server binary so that it can be run from the service

* Add a note for SELinux to change the SELinux context of the agent binary

* Use NOM server-folder as specified in the top paragraph

* Apply suggestions from code review



---------



----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [ ] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!