### PR TITLE
Fix two typos in property names

### DIFF
--- a/modules/ROOT/pages/addition/agent-installation/manual.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/manual.adoc
@@ -37,7 +37,7 @@ Newly created agent will be displayed on the list of agents.
 
 
 [[running-agent]]
-== Runing as a service
+== Running as a service
 To run an agent in service mode means that the agent process runs in the background and monitors the instance.
 The agent lifecycle is handled by the operating system service manager.
 Best practice is to run an agent in service mode.

--- a/modules/ROOT/pages/installation/server.adoc
+++ b/modules/ROOT/pages/installation/server.adoc
@@ -259,7 +259,7 @@ If the NOM Server is required to support self-registered agents, then additional
 | Type of key store used for HTTP traffic
 | PKCS12
 
-| `server.ssl.key-store=file`
+| `server.ssl.key-store`
 | `SERVER_SSL_KEY_STORE`
 |  Location of key store used for HTTP traffic
 | `file:./../certificates/server.pfx`
@@ -279,7 +279,7 @@ If the NOM Server is required to support self-registered agents, then additional
 | Type of key store used for GRPC traffic
 | PKCS12
 
-| `grpc.server.security.key-store-file`
+| `grpc.server.security.key-store`
 | `GRPC_SERVER_SECURITY_KEY_STORE`
 | Location of key store used for GRPC traffic
 | `file:./../certificates/server.pfx`


### PR DESCRIPTION
Corrects configuration key names. The old names never worked.

----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [x] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!