### PR TITLE
Adding page alias to prevent broken link notice

### DIFF
--- a/modules/ROOT/pages/installation/docker/index.adoc
+++ b/modules/ROOT/pages/installation/docker/index.adoc
@@ -1,4 +1,5 @@
 = Docker
+:page-aliases: /docker/server/
 :description: This chapter describes the NOM containerization.
 
 * xref:./container.adoc[NOM Server Docker container] -  About running a NOM server Docker container


### PR DESCRIPTION
Apparently the content was rearranged, causing a 404 error coming from the links featured on the Neo4j Security page (https://neo4j.com/docs/security-docs/). 