### PR TITLE
Simplify the compatibility matrix

### DIFF
--- a/modules/ROOT/pages/appendix/version-compatibility.adoc
+++ b/modules/ROOT/pages/appendix/version-compatibility.adoc
@@ -18,7 +18,7 @@ The NOM agent version should always match the current NOM server version. Other 
 ====
 
 Every Neo4j Ops Manager release relies on compatible subsystems and monitored Neo4j DBMSs for optimal functionality.
-Following table details the compatibility matrix for NOM:
+The following table details the compatibility matrix for NOM:
 
 [cols="<,<,<",options="header"]
 |===

--- a/modules/ROOT/pages/appendix/version-compatibility.adoc
+++ b/modules/ROOT/pages/appendix/version-compatibility.adoc
@@ -14,7 +14,8 @@ Neo4j Ops Manager follows link:https://semver.org/[semantic versioning] for its 
 
 [NOTE]
 ====
-The NOM agent version should always match the current NOM server version. Other configurations may work, but are unsupported.
+The NOM agent version should always match the current NOM server version.
+Other configurations may work, but are unsupported.
 ====
 
 Every Neo4j Ops Manager release relies on compatible subsystems and monitored Neo4j DBMSs for optimal functionality.

--- a/modules/ROOT/pages/appendix/version-compatibility.adoc
+++ b/modules/ROOT/pages/appendix/version-compatibility.adoc
@@ -12,62 +12,61 @@ Neo4j Ops Manager follows link:https://semver.org/[semantic versioning] for its 
 
 == Compatibility matrix
 
+[NOTE]
+====
+The NOM agent version should always match the current NOM server version. Other configurations may work, but are unsupported.
+====
+
 Every Neo4j Ops Manager release relies on compatible subsystems and monitored Neo4j DBMSs for optimal functionality.
 Following table details the compatibility matrix for NOM:
 
-[cols="<,<,<,<,<",options="header"]
+[cols="<,<,<",options="header"]
 |===
 | NOM Release
-| NOM Server
-| NOM Agent
 | NOM Persistence (Neo4j Enterprise)
 | Neo4j DBMS
 
 | 1.0.0
-| 1.0.0
-| 1.0.0
 | >4.4.2
 | >4.4.2
 
-| 1.1.0
-| 1.1.0
 | 1.1.0
 | >4.4.2
 | >4.4.2
 
 | 1.1.1
-| 1.1.1
-| 1.1.1
 | >4.4.2
 | >4.4.2
 
-| 1.2.1
-| 1.2.1
 | 1.2.1
 | >4.4.2, 5.1.0
 | >4.4.2, 5.1.0
 
 | 1.3.x
-| 1.3.x
-| 1.3.x
 | >4.4.2, >5.1.0
 | >4.4.2 (Query log feature not available for 4.4.x DBMSs), >5.1.0
 
 | 1.4.x
-| 1.4.x
-| 1.4.x
 | >4.4.2, >5.1.0
 | >4.4.2 (Query log feature not available for 4.4.x DBMSs), >5.1.0
 
-| 1.5.x
-| 1.5.x
 | 1.5.x
 | >4.4.2, >5.1.0
 | >4.4.2 (Query log feature not available for 4.4.x DBMSs), >5.1.0 (Licence alerts feature only available from Neo4j 5.4.0 onwards)
 
 | 1.6.x
-| 1.6.x
-| 1.6.x
+| >4.4.2, >5.1.0
+| >4.4.2 (Query log feature not available for 4.4.x DBMSs), >5.1.0 (Licence alerts feature only available from 5.4.0 onwards)
+
+| 1.7.x
+| >4.4.2, >5.1.0
+| >4.4.2 (Query log feature not available for 4.4.x DBMSs), >5.1.0 (Licence alerts feature only available from 5.4.0 onwards)
+
+| 1.8.x
+| >4.4.2, >5.1.0
+| >4.4.2 (Query log feature not available for 4.4.x DBMSs), >5.1.0 (Licence alerts feature only available from 5.4.0 onwards)
+
+| 1.9.x
 | >4.4.2, >5.1.0
 | >4.4.2 (Query log feature not available for 4.4.x DBMSs), >5.1.0 (Licence alerts feature only available from 5.4.0 onwards)
 


### PR DESCRIPTION
We have since long had a policy that only the version of the agent matching that of the server is supported, so there is no need to have an exhaustive compat matrix for this. This PR adds 1.9.x release, removes the extraneous columns and adds a note detailing our policy on agent versions.

----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [x] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!