### PR TITLE
Fix merge conflict and add 1.10

### DIFF
--- a/modules/ROOT/pages/appendix/version-compatibility.adoc
+++ b/modules/ROOT/pages/appendix/version-compatibility.adoc
@@ -71,15 +71,7 @@ The following table details the compatibility matrix for NOM:
 | >4.4.2, >5.1.0
 | >4.4.2 (Query log feature not available for 4.4.x DBMSs), >5.1.0 (Licence alerts feature only available from 5.4.0 onwards)
 
-| 1.7.x
-| 1.7.x
-| 1.7.x
-| >4.4.2, >5.1.0
-| >4.4.2 (Query log feature not available for 4.4.x DBMSs), >5.1.0 (Licence alerts feature only available from 5.4.0 onwards)
-
-| 1.8.x
-| 1.8.x
-| 1.8.x
+| 1.10.x
 | >4.4.2, >5.1.0
 | >4.4.2 (Query log feature not available for 4.4.x DBMSs), >5.1.0 (Licence alerts feature only available from 5.4.0 onwards)
 


### PR DESCRIPTION
Due to my fork not being up to date, I ended up introducing a nasty merge conflict when I merged my previous PR. Fixing that and adding 1.10.x to the table.

----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [x] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!