### PR TITLE
Fix step order in docker first look guide (#191)

### DIFF
--- a/modules/ROOT/pages/first-look/docker-first-look.adoc
+++ b/modules/ROOT/pages/first-look/docker-first-look.adoc
@@ -74,9 +74,9 @@ services:
     environment:
       NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
       NEO4J_AUTH: neo4j/<PERSISTENCE_PASSWORD>
-      NEO4J_dbms_default__advertised__address: storage
-      NEO4J_dbms_connector_http_listen__address: storage:9000
-      NEO4J_dbms_connector_bolt_listen__address: storage:9001
+      NEO4J_server_default__advertised__address: storage
+      NEO4J_server_http_listen__address: storage:9000
+      NEO4J_server_bolt_listen__address: storage:9001
     healthcheck:
       test: [ "CMD-SHELL", "echo RETURN 1 | cypher-shell -a bolt://storage:9001 -u neo4j -p <PERSISTENCE_PASSWORD> || exit 1" ]
 
@@ -168,6 +168,16 @@ Edit `docker-compose.yaml` as follows:
 * Replace all occurrences of `<PERSISTENCE_PASSWORD>` with a secure password.
 * Replace all occurrences of `<NEO4J_INSTANCE_PASSWORD>` with a secure password.
 
+== Download the NOM agent
+
+Download NOM agent binaries TAR from link:https://neo4j.com/deployment-center/#tools-tab[the Deployment Center] and execute the following commands in your `INSTALLATION_ROOT`:
+
+[source, shell]
+----
+mkdir agent
+tar -xvf <DOWNLOADED_AGENT_BINARIES_TAR> -C agent --strip-components=1
+----
+
 == Start the Docker compose environment
 Run the following command in your `INSTALLATION_ROOT`:
 
@@ -178,17 +188,10 @@ docker compose -f docker-compose.yaml up
 
 Watch the output and make sure that the Docker containers `storage`, `server` and `db-single` are started successfully.
 
-== Download and start the NOM agent
+== Start the NOM agent
 
-* Download NOM agent binaries TAR from https://neo4j.com/download-center/#ops-manager[here] and execute the following commands in your `INSTALLATION_ROOT`:
-+
-[source, shell]
-----
-mkdir agent
-tar -xvf <DOWNLOADED_AGENT_BINARIES_TAR> -C agent --strip-components=1
-----
-* In `INSTALLATION_ROOT`, start the agent in self-registration mode:
-+
+In `INSTALLATION_ROOT`, start the agent in self-registration mode:
+
 [source, shell]
 ----
 docker compose -f docker-compose.yaml exec db-single sh -c "/agent/bin/agent console -s"

--- a/modules/ROOT/pages/installation/docker/compose.adoc
+++ b/modules/ROOT/pages/installation/docker/compose.adoc
@@ -27,11 +27,11 @@ storage:
     environment:
       NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
       NEO4J_AUTH: <user defined username>/<user defined password>
-      NEO4J_dbms_default__advertised__address: <user defined>
-      NEO4J_dbms_connector_http_listen__address: <user defined>
-      NEO4J_dbms_connector_bolt_listen__address: <user defined to be used in the NOM server>
+      NEO4J_server_default__advertised__address: <user defined>
+      NEO4J_server_http_listen__address: <user defined>
+      NEO4J_server_bolt_listen__address: <user defined to be used in the NOM server>
     healthcheck:
-      test: [ "CMD-SHELL", "echo RETURN 1 | cypher-shell -a <NEO4J_dbms_connector_bolt_listen__address> -u <user defined username> -p <user defined password> || exit 1" ]
+      test: [ "CMD-SHELL", "echo RETURN 1 | cypher-shell -a bolt://<value of NEO4J_server_bolt_listen__address> -u <user defined username> -p <user defined password> || exit 1" ]
 ----
 
 * Define a server service that uses NOM server image. Follow the below template and replace appropriate user defined values. 


### PR DESCRIPTION
* download agent must be before starting the docker compose

* replace deprecated property names

* use the correct link to deployment center



---------



----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [ ] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!