### PR TITLE
Update self-registration docs to reflect security changes (#193)

### DIFF
--- a/modules/ROOT/pages/addition/agent-installation/self-registered.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/self-registered.adoc
@@ -3,13 +3,13 @@
 
 Agent self-registration omits manually acquiring token information from NOM UI as described in xref:./manual.adoc#register[Manually registering agent].
 Instead, minimal configuration of the NOM server is provided to allow the agent to connect and register itself.
-Authorization is granted either through manual approval of the agent in the UI or through mutual authentication.
+Authorization is granted through mutual authentication.
 
 A self-registering agent is useful in an automated environment such as a Kubernetes cluster of Neo4j instances where instances are dynamically created and managed.
 
 [[running-agent]]
 == Run agent 
-To run a self-registering agent, an additional command line option is provided as `-s` for short and `--self-register`.
+To run a self-registering agent, an additional command line option is provided as `-s`, short for `--self-register`.
 
 == Running as a service
 
@@ -50,6 +50,8 @@ Environment="CONFIG_INSTANCE_1_BOLT_USERNAME=<local instance user name>"
 Environment="CONFIG_INSTANCE_1_BOLT_PASSWORD=<local instance password>"
 Environment="CONFIG_INSTANCE_1_QUERY_LOG_PORT=<an available port>"
 Environment="CONFIG_INSTANCE_1_LOG_CONFIG_PATH=<path to server-logs.xml>"
+Environment="CONFIG_TLS_CLIENT_CERT=<path to agent TLS cert>"
+Environment="CONFIG_TLS_CLIENT_KEY=<path to agent TLS key>"
 ----
 
 Please refer to the full list of options <<configuration,here>>.
@@ -101,6 +103,8 @@ CONFIG_INSTANCE_1_BOLT_USERNAME=<local instance user name>
 CONFIG_INSTANCE_1_BOLT_PASSWORD=<local instance password>
 CONFIG_INSTANCE_1_QUERY_LOG_PORT=<an available port>
 CONFIG_INSTANCE_1_LOG_CONFIG_PATH=<path to server-logs.xml>
+CONFIG_TLS_CLIENT_CERT=<path to agent TLS cert>
+CONFIG_TLS_CLIENT_KEY=<path to agent TLS key>
 ----
 
 Please refer to the full list of options <<configuration,here>>.
@@ -145,30 +149,18 @@ image::agents.png[width=800]
 . Find self-registered agent in list.
  ** If the agent is not in the list then go back to where the agent is running and check the logs.
     It may be that the server address is configured incorrectly or the TLS certificates are not correctly specified. 
-
-. Approve agent if required.
-** An agent in standby mode shows up in the list of agents in NOM UI with `Unauthorized` status. 
 +
-image::agent-unauthorized.png[width=800]
-To enable the agent to continue its normal execution, the agent needs to be approved from the NOM UI as shown below:
-.. Click on `...` agent action icon and click `Approve Agent`:
+. Upon successful registration, the agent status changes to `Offline` until the agent receives token information and re-connects to NOM server.
 +
-image::agent-action-menu.png[width=800]
-.. Update agent name or description if desired and click 'Approve':
-+
-image::agent-approve.png[width=800]
-.. Upon approval, the agent status changes to `Offline` until the agent receives token information and re-connects to NOM server.
-+
-image::agent-approved-offline.png[width=800]
-.. Wait for agent status to change to `Online` indicating that the agent has successfully re-connected to the NOM server and is in normal execution mode. 
+. Wait for agent status to change to `Online` indicating that the agent has successfully re-connected to the NOM server. 
 This can take a few minutes. 
 +
 image::agent-approved-online.png[width=800]
-. If the agent status is not 'Online' then go to where it is running and check the logs.
+. If the agent status is not `Online` then check for errors in server logs and agent logs respectively.
 . Hover over the newly added agent and select "View Configuration" from the menu on the right to show agent configuration. 
 Check configuration is as expected.
 . Navigate to the home page (if this agent is the first to manage an instance in a DBMS, it may take a few minutes for the DBMS to appear).
-. Select the _Alerts_ tab and make sure that there are no alerts for any of the DBMSs managed by the new agent.
+. Select the **Alerts** tab and make sure that there are no alerts for any of the DBMSs managed by the new agent.
 
 
 [[configuration]]
@@ -203,7 +195,7 @@ Most operating systems default to the system-wide trusted certificates, but this
 For this reason, you **must** set this environment variable on Windows.
 ====
 
-The following optional configuration can be used to specify the location for  xref:./agent-config-file.adoc[agent config file]: 
+Optional configuration to be used to specify the location for  xref:./agent-config-file.adoc[agent config file]: 
 
 [cols="<,<,<,<",options="header"]
 |===
@@ -240,20 +232,12 @@ Agent meta-data can be optionally specified using these configuration parameters
 
 [IMPORTANT]
 ====
-It's recommended to set agent name and description if multiple agents are being self-registered on similar hosts as it would lead to confusion with similarly named agents appearing in UI for approval.
+It's recommended to set agent name and description if multiple agents are being self-registered on similar hosts as it would lead to confusion with similarly named agents appearing in UI.
 ====
 
 [[agent_mtls]]
-==== Additional configuration for mutual authentication (optional)
+==== Configuration for mutual authentication
 
-With only the above configuration, the agent will connect to NOM server, register itself and then enter *Standby mode*.
-
-*Standby mode* is the runtime state of a self-registering agent which is not authorized yet to monitor instances. 
-In this mode agent keeps checking with NOM server for approval status at every preset time interval (__default 30 seconds__).
-
-The agent exits *Standby mode* once it has been manually approved in the UI. 
-
-Mutual authentication eliminates the manual approval step. 
 The NOM server immediately authorizes an agent that registers using a trusted certificate.
 
 The following configuration is required to enable mutual authentication:
@@ -275,12 +259,13 @@ The following configuration is required to enable mutual authentication:
 
 [IMPORTANT]
 ====
-In addition to the above configuration, the NOM server also needs to be configured to trust the agent certificates as described xref:/installation/server.adoc#config_ref[here].
+In addition to the above configuration, the NOM server also needs to be configured to trust the agent certificates as described xref:/installation/server.adoc#self-registration-config[here]. The client certificate set by `CONFIG_TLS_CLIENT_CERT` should be part of the `GRPC_SERVER_SECURITY_TRUST_CERT_COLLECTION` file.
 ====
 
 [NOTE]
 ====
 Self-signed certificates for agents in test and demo environments can be generated as documented xref:./agent-self-signed-certificates.adoc[here].
+One agent certificate which is not tied to host IPs of agents can be used to configure multiple agents which will reduce the number of agent certificates to maintain.
 ====
 
 ===  Agent logging configuration

--- a/modules/ROOT/pages/first-look/docker-first-look.adoc
+++ b/modules/ROOT/pages/first-look/docker-first-look.adoc
@@ -104,7 +104,6 @@ services:
       CORS_ALLOWEDHEADERS: "*"
       CORS_ALLOWEDORIGINS: "http://localhost:[*],https://localhost:[*], http://server:[*]"
       GRPC_SERVER_SECURITY_TRUST_CERT_COLLECTION: file:/certificates/server.cer
-      GRPC_SERVER_SECURITY_CLIENT_AUTH: OPTIONAL
     volumes:
       - type: bind
         source: ~/.nom/ssc

--- a/modules/ROOT/pages/installation/docker/compose.adoc
+++ b/modules/ROOT/pages/installation/docker/compose.adoc
@@ -56,7 +56,6 @@ storage:
       GRPC_SERVER_SECURITY_KEY_STORE_TYPE: PKCS12
       GRPC_SERVER_SECURITY_KEY_STORE: <path to a self-signed cert file with pfx extension mounted into this container>
       GRPC_SERVER_SECURITY_KEY_STORE_PASSWORD: <user defined for mounted certs>
-      GRPC_SERVER_SECURITY_CLIENT_AUTH: "OPTIONAL"
       CORS_ALLOWEDHEADERS: "*"
       CORS_ALLOWEDORIGINS: "http://localhost:[*],https://localhost:[*]"
     volumes:

--- a/modules/ROOT/pages/installation/docker/container.adoc
+++ b/modules/ROOT/pages/installation/docker/container.adoc
@@ -42,7 +42,6 @@ docker run -e "JAVA_OPTS=<Value>" neo4j/neo4j-ops-manager-server \
     --grpc.server.security.key-store-type=PKCS12 \
     --grpc.server.security.key-store=<Value> \
     --grpc.server.security.key-store-password=<Value> \
-    --grpc.server.security.clientAuth=OPTIONAL
 ----
 
 . As environment variables
@@ -62,7 +61,6 @@ docker run \
     -e "GRPC_SERVER_SECURITY_KEY_STORE_TYPE=PKCS12" \
     -e "GRPC_SERVER_SECURITY_KEY_STORE=<Value>" \
     -e "GRPC_SERVER_SECURITY_KEY_STORE_PASSWORD=<Value>" \
-    -e "GRPC_SERVER_SECURITY_CLIENT_AUTH=OPTIONAL" \
     neo4j/neo4j-ops-manager-server
 ----
 

--- a/modules/ROOT/pages/installation/kubernetes/helm-charts.adoc
+++ b/modules/ROOT/pages/installation/kubernetes/helm-charts.adoc
@@ -14,57 +14,57 @@
 * Following is the reference `values.yaml` for NOM server Helm Chart:
 ----
 # Default values for neo4j-ops-manager-server.
-server:
 
+# Refer to "https://neo4j.com/docs/ops-manager/current/installation/server/#config_ref"
 config:
-  logFileName: "app.log"
+  logFileName: ""
   logLevel: "info"
   maxHeapSize: "8g"
   jwtTTL: "2h"
-  grpc:
-    advertisedHost: ""
+  grpcAdvertisedHost: "" # this needs to be set if a different IP assigned to GRPC
+  grpcAdvertisedPort: "" # this needs to be set if a different IP assigned to GRPC
 
-## An optional reference to a secret that contains some or all values for NOM secrets
-## Secret name and key should be specified
-#secretsFromSecrets:
-#  # storage keys
-#  storageUri:
-#    secretName: ""
-#    key: "" # key in Secret for Storage URI
-#  storageUsername:
-#    secretName: ""
-#    key: "" # key in Secret for Storage username
-#  storagePassword:
-#    secretName: ""
-#    key: "" # key in Secret for Storage URI
-#  # tls keys
-#  tlsPassword:
-#    secretName: ""
-#    key: "" # key in Secret for tls password
-#  # jwt keys
-#  jwtSecret:
-#    secretName: ""
-#    key: "" # key in Secret for jwt secret
+# An optional reference to a secret that contains some or all values for NOM secrets
+# Secret name and key should be specified
+secretsFromSecrets:
+  # storage keys
+  storageUri:
+    secretName: ""
+    key: "" # key in Secret for Storage URI
+  storageUsername:
+    secretName: ""
+    key: "" # key in Secret for Storage username
+  storagePassword:
+    secretName: ""
+    key: "" # key in Secret for Storage URI
+  # tls keys
+  tlsPassword:
+    secretName: ""
+    key: "" # key in Secret for tls password
+  tlsPkcs12CertFileContent:
+    secretName: ""
+    key: "" # key in Secret for tls pkcs12CertFileContent
+  # jwt keys
+  jwtSecret:
+    secretName: ""
+    key: "" # key in Secret for jwt secret
+  # mTls keys
+  mTlsAgentCerts:
+    secretName: ""
+    key: "" # key in Secret for mTls agentCerts
 
 secrets:
-  storage:
-    uri: "" # NOM persistence URI
-    username: "" # NOM persistence user name
-    password: "" # NOM persistence password
-
-#  # jwt secret is optional, NOM server generates a secure cryptographic secret if not set
-#  jwt:
-#    secret: "" # jwt secret as specified in server installation
-
-  tls:
-    password: "" # PKCS12 certificate file password for server TLS config
-    pkcs12CertFileContent: "" # A base64 encoded string of pfx/pkcs12 file content
-
-#  # mTls is optional, uncomment the below to set
-#  mTls:
-#     # string content of PEM encoded list of certificates appended into a .pem file
-#     # used for agent self-registration
-#    agentCerts: ""
+  # storage
+  storageUri: ""
+  storageUsername: ""
+  storagePassword: ""
+  # tls
+  tlsPassword: ""
+  tlsPkcs12CertFileContent: ""
+  # jwt
+  jwtSecret: ""
+  # mTls
+  mTlsAgentCerts: ""
 
 service:
   http:
@@ -73,15 +73,16 @@ service:
     # internal load balancers in Azure Kubernetes Service (AKS) when public external IP addresses are less secure for
     # the K8s environment
     annotations: { }
-    ipAddress: ""
+    port: 443
+    loadBalancerIP: "" # optional static load balancer IP
   grpc:
     # annotations for grpc service
     # For example, `service.beta.kubernetes.io/azure-load-balancer-internal: "true"` is an annotation used to enable
     # internal load balancers in Azure Kubernetes Service (AKS) when public external IP addresses are less secure for
     # the K8s environment
     annotations: { }
-    ipAddress: ""
     port: 9090
+    loadBalancerIP: "" # optional static load balancer IP
 
 image:
   name: neo4j/neo4j-ops-manager-server
@@ -92,6 +93,8 @@ hpa:
     targetCPUUtilizationPercentage: 70
 
 nameOverride:
+
+additionalVolumeMounts:
 
 resources:
   limits:
@@ -111,13 +114,13 @@ affinity: {}
 * Run the following command to install the NOM server to your Kubernetes cluster
 [source, shell, role=noheader]
 ----
-helm install -f values.yaml --set secrets.tls.pkcs12CertFileContent=$(cat server.pfx | base64) <Helm release name> /path/to/neo4j-ops-manager-server-<VERSION>.tgz
+helm install -f values.yaml --set secrets.tlsPkcs12CertFileContent=$(cat server.pfx | base64) <Helm release name> /path/to/neo4j-ops-manager-server-<VERSION>.tgz
 ----
 
 * If agents are self-registered, set the additional trusted agent certificates on the server before deploying the agents
 [source, shell, role=noheader]
 ----
-helm install -f values.yaml --set secrets.tls.pkcs12CertFileContent=$(cat server.pfx | base64) --set secrets.mTls.agentCerts=$(cat localhost.pem | base64) <Helm release name> /path/to/neo4j-ops-manager-server-<VERSION>.tgz
+helm install -f values.yaml --set secrets.tlsPkcs12CertFileContent=$(cat server.pfx | base64) --set secrets.mTlsAgentCerts=$(cat localhost.pem | base64) <Helm release name> /path/to/neo4j-ops-manager-server-<VERSION>.tgz
 ----
 
 * If the command doesn't report any error, check if the NOM server pod and services are running with `kubectl` command.
@@ -142,15 +145,17 @@ config:
     advertisedHost: "https://localhost:9090"
 
 secrets:
-  storage:
-    uri: "neo4j://localhost:7687"
-    username: "neo4j"
-    password: "password"
-    # jwt:
-    #   secret: "<secret>"
-  tls:
-    password: "changeit"
-    pkcs12CertFileContent: "<base64 encoded string of pkcs12 server cert content>"
+  # storage
+  storageUri: "neo4j://localhost:7687"
+  storageUsername: "neo4j"
+  storagePassword: "passw0rd"
+  # tls
+  tlsPassword: "changeit"
+  tlsPkcs12CertFileContent: "<base64 encoded string of pkcs12 server cert content>"
+  # jwt
+  jwtSecret: ""
+  # mTls
+  mTlsAgentCerts: ""
 
 service:
   http:

--- a/modules/ROOT/pages/installation/server.adoc
+++ b/modules/ROOT/pages/installation/server.adoc
@@ -220,9 +220,23 @@ If you set all the arguments to environment variables, you can shorten the serve
 java -jar .\lib\server.jar
 ----
 
+[[self-registration-config]]
 [NOTE]
 ====
-If the NOM Server is required to support self-registered agents, then additional configuration needs to be provided to above commands as mentioned in the configuration reference table. More about agent self-registration xref:../addition/agent-installation/self-registered.adoc[here]
+If the NOM Server is required to support self-registered agents, then additional configuration properties needs to be provided to above commands. 
+These include:
+
+```
+GRPC_SERVER_SECURITY_TRUST_CERT_COLLECTION
+
+or
+
+grpc.server.security.trustCertCollection
+```
+
+which are described in the configuration reference table.
+
+More about agent self-registration xref:../addition/agent-installation/self-registered.adoc#agent_mtls[here]
 ====
 
 == Server configuration reference [[config_ref]]
@@ -308,13 +322,6 @@ If the NOM Server is required to support self-registered agents, then additional
 | `GRPC_SERVER_SECURITY_TRUST_CERT_COLLECTION`
 | File containing list of PEM encoded agent certificates. Required for agent self-registration. (optional)
 | `file:/path/to/agent-certs.pem`
-
-| `grpc.server.security.clientAuth`
-| `GRPC_SERVER_SECURITY_CLIENT_AUTH`
-| Option to indicate whether to verify client certificates. 
-Required for agent self-registration. 
-Possible values: `OPTIONAL` to simultaneously allow manual registration or `REQUIRE` to only allow mutually authenticated agents.
-| `OPTIONAL`
 
 | `logging.file.name`
 | `LOGGING_FILE_NAME`


### PR DESCRIPTION
* Update self-registration docs to reflect security changes

* update helm charts examples

* Apply suggestions from code review



* correct plain secret name in commands

* remove mtls auth config that's set by default

* remove property based client auth references

* Update modules/ROOT/pages/addition/agent-installation/self-registered.adoc



---------



----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [ ] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!