### PR TITLE
Clarify instance config

### DIFF
--- a/modules/ROOT/pages/addition/agent-installation/manual.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/manual.adoc
@@ -242,12 +242,12 @@ The following environment variables specify log configuration for the *agent*:
 
 === Monitored instance configuration
 
-For each managed DBMS instance on the host, the following environment variables need to be set to allow the agent to access the instance.
+The following environment variables need to be set to allow the agent to access the instance.
 
 [NOTE]
 ====
 If there is more than one DBMS being monitored by the same agent, repeat and enumerate the configuration of each DBMS by replacing the digit `1` below with `2`, `3`, and so on, for each instance.
-For example, name the first DBMS with `CONFIG_INSTANCE_1_NAME`, and the second with `CONFIG_INSTANCE_2_NAME`.
+For example, name the first DBMS with `CONFIG_INSTANCE_1_NAME`, and the second with `CONFIG_INSTANCE_2_NAME`, and so on.
 ====
 
 [cols="<,<,<",options="header"]

--- a/modules/ROOT/pages/addition/agent-installation/manual.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/manual.adoc
@@ -244,7 +244,7 @@ The following environment variables specify log configuration for the *agent*:
 
 The following environment variables need to be set to allow the agent to access the instance.
 
-[NOTE]
+[IMPORTANT]
 ====
 If there is more than one DBMS being monitored by the same agent, repeat and enumerate the configuration of each DBMS by replacing the digit `1` below with `2`, `3`, and so on, for each instance.
 For example, name the first DBMS with `CONFIG_INSTANCE_1_NAME`, and the second with `CONFIG_INSTANCE_2_NAME`, and so on.
@@ -272,6 +272,12 @@ For example, name the first DBMS with `CONFIG_INSTANCE_1_NAME`, and the second w
 | Bolt password for first instance
 | password
 |===
+
+[NOTE]
+====
+The instance name that you specify for `CONFIG_INSTANCE_n_NAME` will be used to identify your instance in NOM.
+For this reason, it is important that you specify unique names across your cluster.
+====
 
 [[querylog]]
 ==== Query log collection configuration
@@ -308,16 +314,6 @@ If set, appends the appropriate log appender automatically (including the port s
 | Collect and show queries coming from the NOM agent (optional)
 | true
 |===
-
-[IMPORTANT]
-====
-Environment variable considerations:
-
-* The digit `1` in the above environment variables can be exchanged with `1`, `2`, etc. for each of the monitored DBMS instances on the same host, if there is more than one.
-* The instance name that you specify for `CONFIG_INSTANCE_n_NAME` will be used to identify your instance on NOM.
-For this reason, it is important that you specify unique names across your cluster.
-====
-
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/addition/agent-installation/manual.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/manual.adoc
@@ -248,6 +248,7 @@ For each managed DBMS instance on the host, the following environment variables 
 ====
 If there is more than one DBMS being monitored by the same agent, repeat and enumerate the configuration of each DBMS by replacing the digit `1` below with `2`, `3`, and so on, for each instance.
 For example, name the first DBMS with `CONFIG_INSTANCE_1_NAME`, and the second with `CONFIG_INSTANCE_2_NAME`.
+====
 
 [cols="<,<,<",options="header"]
 |===

--- a/modules/ROOT/pages/addition/agent-installation/manual.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/manual.adoc
@@ -242,7 +242,12 @@ The following environment variables specify log configuration for the *agent*:
 
 === Monitored instance configuration
 
-For each managed DBMS instance on the host, the following environment variables need to be set to allow the agent to access the instance:
+For each managed DBMS instance on the host, the following environment variables need to be set to allow the agent to access the instance.
+
+[NOTE]
+====
+If there is more than one DBMS being monitored by the same agent, repeat and enumerate the configuration of each DBMS by replacing the digit `1` below with `2`, `3`, and so on, for each instance.
+For example, name the first DBMS with `CONFIG_INSTANCE_1_NAME`, and the second with `CONFIG_INSTANCE_2_NAME`.
 
 [cols="<,<,<",options="header"]
 |===
@@ -250,20 +255,20 @@ For each managed DBMS instance on the host, the following environment variables 
 | Description
 | Example
 
-| `CONFIG_INSTANCE_n_NAME`
-| Name of nth instance
-| my-instance-n
+| `CONFIG_INSTANCE_1_NAME`
+| Name of first instance
+| my-instance-1
 
-| `CONFIG_INSTANCE_n_BOLT_URI`
-| Bolt URI for nth instance with bolt or bolt+s protocol
+| `CONFIG_INSTANCE_1_BOLT_URI`
+| Bolt URI for first instance with bolt or bolt+s protocol
 | bolt://localhost:7687 or bolt+s://localhost:7687 or bolt+ssc://localhost:7687, depending on the local database setup
 
-| `CONFIG_INSTANCE_n_BOLT_USERNAME`
-| Bolt user name for nth instance
+| `CONFIG_INSTANCE_1_BOLT_USERNAME`
+| Bolt username for first instance
 | neo4j
 
-| `CONFIG_INSTANCE_n_BOLT_PASSWORD`
-| Bolt password for nth instance
+| `CONFIG_INSTANCE_1_BOLT_PASSWORD`
+| Bolt password for first instance
 | password
 |===
 
@@ -276,29 +281,29 @@ For each managed DBMS instance on the host, the following environment variables 
 | Description
 | Example
 
-| `CONFIG_INSTANCE_n_QUERY_LOG_PORT`
+| `CONFIG_INSTANCE_1_QUERY_LOG_PORT`
 | Port for connecting the agent to the Neo4j log4j appender.
 If not set, the query log collection feature is treated as disabled.
 | 9500
 
-| `CONFIG_INSTANCE_n_LOG_CONFIG_PATH`
+| `CONFIG_INSTANCE_1_LOG_CONFIG_PATH`
 | Path to the instance xref:../addition/../addition/instance-requirements.adoc#server_log_config[log4j config file].
 If set, appends the appropriate log appender automatically (including the port specified above).
 | /var/lib/neo4j/conf/server-logs.xml
 
-| `CONFIG_INSTANCE_n_QUERY_LOG_MIN_DURATION`
+| `CONFIG_INSTANCE_1_QUERY_LOG_MIN_DURATION`
 | Minimum duration in milliseconds for a query to be logged (optional)
 | 100
 
-| `CONFIG_INSTANCE_n_QUERY_LOG_MIN_DURATION_FILTER_ERRORS`
+| `CONFIG_INSTANCE_1_QUERY_LOG_MIN_DURATION_FILTER_ERRORS`
 | Enable filter for errors under the minimum duration in milliseconds (optional)
 | true
 
-| `CONFIG_INSTANCE_n_QUERY_LOG_DISABLE_OBFUSCATION`
+| `CONFIG_INSTANCE_1_QUERY_LOG_DISABLE_OBFUSCATION`
 | Disable the string literal obfuscation in queries (optional)
 | true
 
-| `CONFIG_INSTANCE_n_QUERY_LOG_INCLUDE_AGENT`
+| `CONFIG_INSTANCE_1_QUERY_LOG_INCLUDE_AGENT`
 | Collect and show queries coming from the NOM agent (optional)
 | true
 |===
@@ -307,8 +312,7 @@ If set, appends the appropriate log appender automatically (including the port s
 ====
 Environment variable considerations:
 
-* `n` in the above environment variables needs to be replaced with `1`, `2`, etc. for each of the monitored DBMS instances on the same host.
-For example, for a single monitored DBMS, the environment variables must be named as `CONFIG_INSTANCE_1_NAME`, `CONFIG_INSTANCE_1_BOLT_URI`, `CONFIG_INSTANCE_1_BOLT_USERNAME` and `CONFIG_INSTANCE_1_BOLT_PASSWORD`.
+* The digit `1` in the above environment variables can be exchanged with `1`, `2`, etc. for each of the monitored DBMS instances on the same host, if there is more than one.
 * The instance name that you specify for `CONFIG_INSTANCE_n_NAME` will be used to identify your instance on NOM.
 For this reason, it is important that you specify unique names across your cluster.
 ====

--- a/modules/ROOT/pages/addition/agent-installation/self-registered.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/self-registered.adoc
@@ -288,7 +288,14 @@ The following environment variables specify start configuration for the agent:
 
 
 === Monitored instance configuration
-For each managed DBMS instance on the host, the following environment variables need to be set to allow the agent to access the instance:
+
+For each managed DBMS instance on the host, the following environment variables need to be set to allow the agent to access the instance.
+
+[NOTE]
+====
+If there is more than one DBMS being monitored by the same agent, repeat and enumerate the configuration of each DBMS by replacing the digit `1` below with `2`, `3`, and so on, for each instance.
+For example, name the first DBMS with `CONFIG_INSTANCE_1_NAME`, and the second with `CONFIG_INSTANCE_2_NAME`.
+====
 
 [cols="<,<,<",options="header"]
 |===
@@ -296,20 +303,20 @@ For each managed DBMS instance on the host, the following environment variables 
 | Description
 | Example
 
-| `CONFIG_INSTANCE_n_NAME`
-| Name of nth instance
-| my-instance-n
+| `CONFIG_INSTANCE_1_NAME`
+| Name of first instance
+| my-instance-1
 
-| `CONFIG_INSTANCE_n_BOLT_URI`
-| Bolt URI for nth instance with bolt or bolt+s protocol
+| `CONFIG_INSTANCE_1_BOLT_URI`
+| Bolt URI for first instance with bolt or bolt+s protocol
 | bolt://localhost:7687 or bolt+s://localhost:7687 or bolt+ssc://localhost:7687, depending on the local database setup
 
-| `CONFIG_INSTANCE_n_BOLT_USERNAME`
-| Bolt user name for nth instance
+| `CONFIG_INSTANCE_1_BOLT_USERNAME`
+| Bolt username for first instance
 | neo4j
 
-| `CONFIG_INSTANCE_n_BOLT_PASSWORD`
-| Bolt password for nth instance
+| `CONFIG_INSTANCE_1_BOLT_PASSWORD`
+| Bolt password for first instance
 | password
 |===
 
@@ -322,29 +329,29 @@ For each managed DBMS instance on the host, the following environment variables 
 | Description
 | Example
 
-| `CONFIG_INSTANCE_n_QUERY_LOG_PORT`
+| `CONFIG_INSTANCE_1_QUERY_LOG_PORT`
 | Port for connecting the agent to the Neo4j log4j appender.
 If not set, the query log collection feature is treated as disabled.
 | 9500
 
-| `CONFIG_INSTANCE_n_LOG_CONFIG_PATH`
+| `CONFIG_INSTANCE_1_LOG_CONFIG_PATH`
 | Path to the instance xref:../addition/../addition/instance-requirements.adoc#server_log_config[log4j config file].
 If set, appends the appropriate log appender automatically (including the port specified above).
 | /var/lib/neo4j/conf/server-logs.xml
 
-| `CONFIG_INSTANCE_n_QUERY_LOG_MIN_DURATION`
+| `CONFIG_INSTANCE_1_QUERY_LOG_MIN_DURATION`
 | Minimum duration in milliseconds for a query to be logged (optional)
 | 100
 
-| `CONFIG_INSTANCE_n_QUERY_LOG_MIN_DURATION_FILTER_ERRORS`
+| `CONFIG_INSTANCE_1_QUERY_LOG_MIN_DURATION_FILTER_ERRORS`
 | Enable filter for errors under the minimum duration in milliseconds (optional)
 | true
 
-| `CONFIG_INSTANCE_n_QUERY_LOG_DISABLE_OBFUSCATION`
+| `CONFIG_INSTANCE_1_QUERY_LOG_DISABLE_OBFUSCATION`
 | Disable the string literal obfuscation in queries (optional)
 | true
 
-| `CONFIG_INSTANCE_n_QUERY_LOG_INCLUDE_AGENT`
+| `CONFIG_INSTANCE_1_QUERY_LOG_INCLUDE_AGENT`
 | Collect and show queries coming from the NOM agent (optional)
 | true
 |===
@@ -353,8 +360,7 @@ If set, appends the appropriate log appender automatically (including the port s
 ====
 Environment variable considerations:
 
-* `n` in the above environment variables needs to be replaced with `1`, `2`, etc. for each of the monitored DBMS instances on the same host.
-For example, for a single monitored DBMS, the environment variables must be named as `CONFIG_INSTANCE_1_NAME`, `CONFIG_INSTANCE_1_BOLT_URI`, `CONFIG_INSTANCE_1_BOLT_USERNAME` and `CONFIG_INSTANCE_1_BOLT_PASSWORD`.
+* The digit `1` in the above environment variables can be exchanged with `1`, `2`, etc. for each of the monitored DBMS instances on the same host, if there is more than one.
 * The instance name that you specify for `CONFIG_INSTANCE_n_NAME` will be used to identify your instance on NOM.
 For this reason, it is important that you specify unique names across your cluster.
 ====

--- a/modules/ROOT/pages/addition/agent-installation/self-registered.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/self-registered.adoc
@@ -289,12 +289,12 @@ The following environment variables specify start configuration for the agent:
 
 === Monitored instance configuration
 
-For each managed DBMS instance on the host, the following environment variables need to be set to allow the agent to access the instance.
+The following environment variables need to be set to allow the agent to access the instance.
 
 [NOTE]
 ====
 If there is more than one DBMS being monitored by the same agent, repeat and enumerate the configuration of each DBMS by replacing the digit `1` below with `2`, `3`, and so on, for each instance.
-For example, name the first DBMS with `CONFIG_INSTANCE_1_NAME`, and the second with `CONFIG_INSTANCE_2_NAME`.
+For example, name the first DBMS with `CONFIG_INSTANCE_1_NAME`, and the second with `CONFIG_INSTANCE_2_NAME`, and so on.
 ====
 
 [cols="<,<,<",options="header"]

--- a/modules/ROOT/pages/addition/agent-installation/self-registered.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/self-registered.adoc
@@ -286,12 +286,11 @@ The following environment variables specify start configuration for the agent:
 | `/var/log/nom-agent/log.txt`
 |===
 
-
 === Monitored instance configuration
 
 The following environment variables need to be set to allow the agent to access the instance.
 
-[NOTE]
+[IMPORTANT]
 ====
 If there is more than one DBMS being monitored by the same agent, repeat and enumerate the configuration of each DBMS by replacing the digit `1` below with `2`, `3`, and so on, for each instance.
 For example, name the first DBMS with `CONFIG_INSTANCE_1_NAME`, and the second with `CONFIG_INSTANCE_2_NAME`, and so on.
@@ -319,6 +318,12 @@ For example, name the first DBMS with `CONFIG_INSTANCE_1_NAME`, and the second w
 | Bolt password for first instance
 | password
 |===
+
+[NOTE]
+====
+The instance name that you specify for `CONFIG_INSTANCE_n_NAME` will be used to identify your instance in NOM.
+For this reason, it is important that you specify unique names across your cluster.
+====
 
 [[querylog]]
 ==== Query log collection configuration
@@ -355,15 +360,6 @@ If set, appends the appropriate log appender automatically (including the port s
 | Collect and show queries coming from the NOM agent (optional)
 | true
 |===
-
-[IMPORTANT]
-====
-Environment variable considerations:
-
-* The digit `1` in the above environment variables can be exchanged with `1`, `2`, etc. for each of the monitored DBMS instances on the same host, if there is more than one.
-* The instance name that you specify for `CONFIG_INSTANCE_n_NAME` will be used to identify your instance on NOM.
-For this reason, it is important that you specify unique names across your cluster.
-====
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/installation/server.adoc
+++ b/modules/ROOT/pages/installation/server.adoc
@@ -17,7 +17,10 @@ In any case, please extract the content from the downloaded `.zip` or `.tar.gz` 
 
 == Prerequisites
 
-* Windows or unix-based operating system
+* 1 CPU core (2 recommended)
+* 2 GB RAM (4 GB recommended)
+* 15 GB disk space
+* Windows or Unix-based operating system
 * Java 17 or 21
 * Key pair and certificate (as a PKCS12 file) to be used for TLS protected endpoints (see xref:installation/self-signed-certificate.adoc[] for test and demo purposes).
 If key pair and certificate were generated with OpenSSL, ensure that OpenSSL version 3.x or later was used.


### PR DESCRIPTION
* Rather than listing all parameters in their generic form using an _n_ placeholder, list them out for the first DBMS. The recommended and most common use case is to have one agent per DBMS anyway, so I think it makes sense to start from this as the default configuration. Treat 2nd, 3rd etc DBMS as a special case instead.
* Add system requirements for server

NOTE: The doc preview is serving an outdated commit for this PR, at least for me.

----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [x] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!