### PR TITLE
Document optout.version-check

### DIFF
--- a/modules/ROOT/pages/installation/server.adoc
+++ b/modules/ROOT/pages/installation/server.adoc
@@ -328,6 +328,7 @@ For details about configuring proxy in Java, see link:https://docs.oracle.com/en
 | `optout.version-check`
 | `OPTOUT_VERSION_CHECK`
 | Set to true to opt out of automatic fetching of version information for NOM and Neo4j (optional)
+| false
 
 | `grpc.server.security.trustCertCollection`
 | `GRPC_SERVER_SECURITY_TRUST_CERT_COLLECTION`

--- a/modules/ROOT/pages/installation/server.adoc
+++ b/modules/ROOT/pages/installation/server.adoc
@@ -325,6 +325,10 @@ For details about configuring proxy in Java, see link:https://docs.oracle.com/en
 | Set to true to opt out of crash analytics being sent to Neo4j (optional)
 | false
 
+| `optout.version-check`
+| `OPTOUT_VERSION_CHECK`
+| Set to true to opt out of automatic fetching of version information for NOM and Neo4j (optional)
+
 | `grpc.server.security.trustCertCollection`
 | `GRPC_SERVER_SECURITY_TRUST_CERT_COLLECTION`
 | File containing list of PEM encoded agent certificates. Required for agent self-registration. (optional)


### PR DESCRIPTION

----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [ ] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!