### PR TITLE
Recommend 5.23+ users to disable jmx

### DIFF
--- a/modules/ROOT/pages/addition/instance-requirements.adoc
+++ b/modules/ROOT/pages/addition/instance-requirements.adoc
@@ -66,7 +66,7 @@ For the metrics collection feature to work correctly, these configuration settin
 
 ** `server.metrics.filter=*`
 
-** Discovery service v2 *or* `server.metrics.jmx.enabled=true` (JMX)
+** Discovery service v2 *or* `server.metrics.jmx.enabled=true` (JMX metrics)
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/addition/instance-requirements.adoc
+++ b/modules/ROOT/pages/addition/instance-requirements.adoc
@@ -70,7 +70,8 @@ For the metrics collection feature to work correctly, these configuration settin
 
 [NOTE]
 ====
-For Neo4j versions prior to 5.23, enabling link:https://neo4j.com/docs/java-reference/current/jmx-metrics/[JMX] is a requirement. For versions 5.23 or newer, it is recommended to leave JMX disabled and instead use link:https://neo4j.com/docs/operations-manual/current/clustering/setup/discovery/[discovery service v2].
+For Neo4j versions prior to 5.23, enabling link:https://neo4j.com/docs/java-reference/current/jmx-metrics/[JMX metrics] is a requirement.
+For versions 5.23 or newer, it is recommended to leave JMX metrics disabled and instead use link:https://neo4j.com/docs/operations-manual/current/clustering/setup/discovery/[discovery service v2].
 ====
 
 == User privileges

--- a/modules/ROOT/pages/addition/instance-requirements.adoc
+++ b/modules/ROOT/pages/addition/instance-requirements.adoc
@@ -66,7 +66,12 @@ For the metrics collection feature to work correctly, these configuration settin
 
 ** `server.metrics.filter=*`
 
-** `server.metrics.jmx.enabled=true`
+** Discovery service v2 *or* `server.metrics.jmx.enabled=true` (JMX)
+
+[NOTE]
+====
+For Neo4j versions prior to 5.23, enabling link:https://neo4j.com/docs/java-reference/current/jmx-metrics/[JMX] is a requirement. For versions 5.23 or newer, it is recommended to leave JMX disabled and instead use link:https://neo4j.com/docs/operations-manual/current/clustering/setup/discovery/[discovery service v2].
+====
 
 == User privileges
 

--- a/modules/ROOT/pages/installation/server.adoc
+++ b/modules/ROOT/pages/installation/server.adoc
@@ -315,11 +315,6 @@ For details about configuring proxy in Java, see link:https://docs.oracle.com/en
 | Random string used for JWT signing (optional)
 | please-set-a-random-secret-string-here-for-jwt-signing
 
-| `jwt.time-to-live`
-| `JWT_TIME_TO_LIVE`
-| Session timeout (optional)
-| 8h
-
 | `optout.crash-analytics`
 | `OPTOUT_CRASH_ANALYTICS`
 | Set to true to opt out of product analytics being sent to Neo4j (optional)

--- a/modules/ROOT/pages/installation/server.adoc
+++ b/modules/ROOT/pages/installation/server.adoc
@@ -315,6 +315,11 @@ For details about configuring proxy in Java, see link:https://docs.oracle.com/en
 | Random string used for JWT signing (optional)
 | please-set-a-random-secret-string-here-for-jwt-signing
 
+| `jwt.time-to-live`
+| `JWT_TIME_TO_LIVE`
+| Session timeout (optional)
+| 8h
+
 | `optout.crash-analytics`
 | `OPTOUT_CRASH_ANALYTICS`
 | Set to true to opt out of product analytics being sent to Neo4j (optional)


### PR DESCRIPTION
With the latest commit, JMX is no longer mandatory as long as discovery service v2 is enabled. As Neo4j discourages the use of JMX, update our documentation to be in line with this recommendation. Not sure which version this change will land in.

----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [x] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!