### PR TITLE
latest actions, update branches

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-./.github/ @recrwplay
+./.github/ @neo4j/team-docops

--- a/.github/workflows/docs-pr-checks.yml
+++ b/.github/workflows/docs-pr-checks.yml
@@ -4,14 +4,13 @@ name: "Verify docs PR"
 on:
   pull_request:
     branches:
-      - "1.10"
       - "dev"
 
 jobs:
 
   #  Generate HTML
   docs-build-pr:
-    uses: neo4j/docs-tools/.github/workflows/reusable-docs-build.yml@v1.1.2
+    uses: neo4j/docs-tools/.github/workflows/reusable-docs-build.yml@v1.2.0
     with:
       deploy-id: ${{ github.event.number }}
       retain-artifacts: 14
@@ -21,7 +20,7 @@ jobs:
   # By default, the job fails if there are errors, passes if there are warnings only.
   docs-verify-pr:
     needs: docs-build-pr
-    uses: neo4j/docs-tools/.github/workflows/reusable-docs-verify.yml@v1.1.2
+    uses: neo4j/docs-tools/.github/workflows/reusable-docs-verify.yml@v1.2.0
     with:
       failOnWarnings: true
 
@@ -38,7 +37,7 @@ jobs:
     steps:
       - name: Get file changes
         id: get-file-changes
-        uses: tj-actions/changed-files@cbda684547adc8c052d50711417fa61b428a9f88 # v41.1.2
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         with:
           separator: ','
           files_yaml: |
@@ -53,7 +52,7 @@ jobs:
   docs-updates-comment-pr:
     if: needs.docs-build-pr.outputs.pages-listed == 'success'
     needs: [docs-build-pr, docs-changes-pr]
-    uses: neo4j/docs-tools/.github/workflows/reusable-docs-pr-changes.yml@v1.1.2
+    uses: neo4j/docs-tools/.github/workflows/reusable-docs-pr-changes.yml@v1.2.0
     with:
       pages-modified: ${{ needs.docs-changes-pr.outputs.pages-modified }}
       pages-added: ${{ needs.docs-changes-pr.outputs.pages-added }}

--- a/.github/workflows/docs-teardown.yml
+++ b/.github/workflows/docs-teardown.yml
@@ -4,7 +4,6 @@ name: "Documentation Teardown"
 on:
   pull_request_target:
     branches:
-      - "1.10"
       - "dev"
     types:
       - closed
@@ -14,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: lts/*
 


### PR DESCRIPTION

----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [x] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!