### PR TITLE
Fix download links & installation instructions

### DIFF
--- a/modules/ROOT/pages/first-look/linux-first-look.adoc
+++ b/modules/ROOT/pages/first-look/linux-first-look.adoc
@@ -9,7 +9,7 @@ NOTE: The query log feature is only available for DBMSs with instances that are 
 == Create persistence DBMS
 
 === Download and extract
-Download latest Neo4j Linux/Mac executable from https://neo4j.com/deployement-center/?current-releases[here] and extract the package.
+Download latest Neo4j Linux/Mac executable from https://neo4j.com/deployment-center/?current-releases[here] and extract the package.
 Extracted directory location is referred to as NEO4J_HOME form now on.
 
 === Change password
@@ -29,11 +29,13 @@ Navigate to NEO4j_HOME and run:
 See link:https://neo4j.com/docs/operations-manual/current/installation/linux/tarball/[Neo4j Linux installation documentation] for more details about installing and running Neo4j.
 
 == Server installation
-=== Unpack NOM server from Neo4j package
+=== Download and unpack NOM server from the package
+
+Download latest NOM server Linux/Mac executable from https://neo4j.com/deployment-center/?current-releases#tools-tab[here] and extract the package.
 
 [source, terminal]
 ----
-   tar -xzf NEO4J_HOME/products/neo4j-ops-manager-server-*-unix.tar.gz
+   tar -xzf neo4j-ops-manager-server-*-unix.tar.gz
 ----
 
 Extracted directory is now known as NOM_SERVER_HOME.

--- a/modules/ROOT/pages/first-look/linux-first-look.adoc
+++ b/modules/ROOT/pages/first-look/linux-first-look.adoc
@@ -9,7 +9,7 @@ NOTE: The query log feature is only available for DBMSs with instances that are 
 == Create persistence DBMS
 
 === Download and extract
-Download latest Neo4j Linux/Mac executable from https://neo4j.com/deployment-center/?current-releases[here] and extract the package.
+Download latest Neo4j Linux executable from https://neo4j.com/deployment-center/?current-releases[here] and extract the package.
 Extracted directory location is referred to as NEO4J_HOME form now on.
 
 === Change password
@@ -31,7 +31,7 @@ See link:https://neo4j.com/docs/operations-manual/current/installation/linux/tar
 == Server installation
 === Download and unpack NOM server from the package
 
-Download latest NOM server Linux/Mac executable from https://neo4j.com/deployment-center/?current-releases#tools-tab[here] and extract the package.
+Download latest NOM server Linux executable from https://neo4j.com/deployment-center/?current-releases#tools-tab[here] and extract the package.
 
 [source, terminal]
 ----

--- a/modules/ROOT/pages/installation/server.adoc
+++ b/modules/ROOT/pages/installation/server.adoc
@@ -8,7 +8,7 @@ The second step is to download and configure arguments and/or environment variab
 Both ways are described below.
 Running as a service is the recommended way of operating the NOM Server.
 
-Releases of Neo4j enterprise all come bundled with the most current version of NOM at the time of that Neo4j release.
+Some Releases of Neo4j enterprise (`< 2025.4.x` or `< 5.26.x`) come bundled with the latest version of NOM at the time of that Neo4j release.
 Please note that this does not have to be the most current version of NOM.
 You can find NOM as `.zip` or `.tar.gz` inside your Neo4j folder under `/products`.
 Alternatively, you can download any version of the NOM Server, including the agent binaries here: https://neo4j.com/deployment-center/?ops-manager[Download].

--- a/modules/ROOT/pages/installation/server.adoc
+++ b/modules/ROOT/pages/installation/server.adoc
@@ -8,10 +8,7 @@ The second step is to download and configure arguments and/or environment variab
 Both ways are described below.
 Running as a service is the recommended way of operating the NOM Server.
 
-Some Releases of Neo4j enterprise (`< 2025.4.x` or `< 5.26.x`) come bundled with the latest version of NOM at the time of that Neo4j release.
-Please note that this does not have to be the most current version of NOM.
-You can find NOM as `.zip` or `.tar.gz` inside your Neo4j folder under `/products`.
-Alternatively, you can download any version of the NOM Server, including the agent binaries here: https://neo4j.com/deployment-center/?ops-manager[Download].
+You can download the latest version of the NOM Server, including the agent binaries here: https://neo4j.com/deployment-center/?ops-manager[Download].
 In any case, please extract the content from the downloaded `.zip` or `.tar.gz` file to whichever directory you want to operate NOM from
 (in the following referenced as NOM server-folder).
 


### PR DESCRIPTION
### this PR;

- Fixes misspelled deployment centre links
- Updates server installation instructions to reflect removed NOM server package from recent Neo4j bundles

[Trello](https://trello.com/c/Xpiitnnt/2764-deployment-centre-link-broken-in-legacy-nom-docs)


----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [x] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!