### PR TITLE
Fix the issue https://github.com/neo4j/docs-ops-manager/issues/266 (#…

### DIFF
--- a/modules/ROOT/pages/addition/docker/container.adoc
+++ b/modules/ROOT/pages/addition/docker/container.adoc
@@ -24,7 +24,7 @@ The following steps describe running a NOM agent in Neo4j container as an additi
 +
 [source, shell]
 ----
-tar -xzf $NEO4J_HOME/products/neo4j-ops-manager-agent-<NOM_VERSION>-linux-amd64.tar.gz --strip-components 1 && mv bin/agent-<NOM_VERSION>-linux-amd64 /bin/agent
+tar -xzf $NEO4J_HOME/products/neo4j-ops-manager-agent-<NOM_VERSION>-linux-amd64.tar.gz --strip-components 1 && mv bin/agent /bin/agent
 ----
 
     ** Mounted
@@ -34,13 +34,6 @@ tar -xzf $NEO4J_HOME/products/neo4j-ops-manager-agent-<NOM_VERSION>-linux-amd64.
 ----
 docker run -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes -v <path/to/agent/binary>:/agent/bin neo4j/neo4j:latest --name <neo4j container name>
 ----
-+
-Wait for the container to be ready and then run :
-+
-[source, shell]
-----
-docker exec -it <neo4j container name> -- /bin/sh -c "mv /agent/bin/agent-*-linux-amd64 /bin/agent"
-----
 
     ** Downloaded
         *** NOM agent package can be directly downloaded on to the Neo4j container and then extracted and installed.
@@ -48,7 +41,7 @@ docker exec -it <neo4j container name> -- /bin/sh -c "mv /agent/bin/agent-*-linu
 [source, shell]
 ----
 wget -O /tmp/neo4j-ops-manager-agent-<NOM_VERSION>-linux-amd64.tar.gz https://dist.neo4j.org/ops-manager/<NOM_VERSION>/neo4j-ops-manager-agent-<NOM_VERSION>-linux-amd64.tar.gz
-tar -xzf /tmp/neo4j-ops-manager-agent-*-linux-amd64.tar.gz --strip-components 1 && mv bin/agent-*-linux-amd64 /bin/agent
+tar -xzf /tmp/neo4j-ops-manager-agent-*-linux-amd64.tar.gz --strip-components 1 && mv bin/agent /bin/agent
 ----
 
 * Run the NOM agent, which involves executing the agent binary with appropriate agent configuration.
@@ -62,8 +55,8 @@ docker exec -dit <neo4j container name> -- /bin/sh 'CONFIG_AGENT_NAME="test_loca
     CONFIG_SERVER_GRPC_ADDRESS="server:9090" \
     CONFIG_SERVER_HTTP_ADDRESS="https://server:8080" \
     CONFIG_TOKEN_URL=https://server:8080/api/login \
-    CONFIG_TOKEN_CLIENT_ID=rj34hg6456ghrhjthet45hg6 \
-    CONFIG_TOKEN_CLIENT_SECRET=5h346jhrjkthkjthjerhtkrt \
+    CONFIG_TOKEN_CLIENT_ID=<client id> \
+    CONFIG_TOKEN_CLIENT_SECRET=<client secret> \
     CONFIG_TLS_TRUSTED_CERTS=/path/to/trusted/certs/pem/file \
     CONFIG_LOG_FILE=/path/to/nom-agent/log.txt \
     CONFIG_LOG_LEVEL="debug" \

--- a/modules/ROOT/pages/installation/persistence.adoc
+++ b/modules/ROOT/pages/installation/persistence.adoc
@@ -19,7 +19,7 @@ NOM comes with a license to run a Neo4j DBMS with up to 4 cores of CPU and up to
 
 === Install and prepare
 
-* Please refer to the link:/docs/operations-manual/current/installation[Operations Manual -> Installation] for information on how to install Neo4j.
+Refer to the link:https://neo4j.com/docs/operations-manual/current/installation/[Operations Manual -> Installation] for information on how to install Neo4j.
 
 * Make sure to set a secure password for the built-in admin (`neo4j`) and/or create a specific user for the NOM Server.
 Be aware that that user needs full admin access.
@@ -45,7 +45,7 @@ This is done via `MATCH (n) RETURN count(n)` which should return 0.
 This is done via `SHOW INDEXES` and `SHOW CONSTRAINTS`.
 
 
-The default database for a user is either the home database for that user if it is set or the default database for the DBMS. 
+The default database for a user is either the home database for that user if it is set or the default database for the DBMS.
 The default database for the DBMS is 'neo4j' if not explicitly configured.
 ====
 


### PR DESCRIPTION
…… (#274)

Fix the issue https://github.com/neo4j/docs-ops-manager/issues/266 (#273)

* fix the issue https://github.com/neo4j/docs-ops-manager/issues/266

* some path fixes

* Update modules/ROOT/pages/addition/docker/container.adoc

---------



----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [ ] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!