### PR TITLE
Cherry pick 278

### DIFF
--- a/modules/ROOT/pages/addition/kubernetes/daemonset.adoc
+++ b/modules/ROOT/pages/addition/kubernetes/daemonset.adoc
@@ -88,7 +88,7 @@ server:
 #   clientCert: "/path/to/agent/cert"
 instances:
   - name: daemonset-agent
-    boltURI: neo4j://localhost:7687
+    boltURI: bolt://localhost:7687
     boltUsername: neo4j
     boltPassword: passw0rd
     queryLogPort: "9500"

--- a/modules/ROOT/pages/addition/kubernetes/sidecar.adoc
+++ b/modules/ROOT/pages/addition/kubernetes/sidecar.adoc
@@ -76,7 +76,7 @@ podSpec:
         - name: CONFIG_INSTANCE_1_NAME 
           value: "side-car-agent"
         - name: CONFIG_INSTANCE_1_BOLT_URI 
-          value: "neo4j://localhost:7687"
+          value: "bolt://localhost:7687"
         - name: CONFIG_INSTANCE_1_BOLT_USERNAME 
           value: "neo4j"
         - name: CONFIG_INSTANCE_1_BOLT_PASSWORD 


### PR DESCRIPTION
cherry pick #278 to `1.13`
----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [x] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!