### PR TITLE
1.15 updates

### DIFF
--- a/preview.yml
+++ b/preview.yml
@@ -45,6 +45,6 @@ asciidoc:
     # sectnums: true, removed so they are off by default
     # sectnumlevel: 3,
     experimental: ''
-    copyright: 2025
+    copyright: 2026
     common-license-page-uri: https://neo4j.com/docs/license/
     check-mark: icon:check[]

--- a/publish.yml
+++ b/publish.yml
@@ -7,7 +7,7 @@ site:
 content:
   sources:
   - url: ./
-    branches: ['1.10', '1.11', '1.12', '1.13', '1.14', 'dev']
+    branches: ['1.10', '1.11', '1.12', '1.13', '1.14', '1.15']
     exclude:
     - '!**/_includes/*'
     - '!**/readme.adoc'
@@ -43,6 +43,6 @@ asciidoc:
     includePDF: false
     nonhtmloutput: ""
     experimental: ''
-    copyright: 2025
+    copyright: 2026
     common-license-page-uri: https://neo4j.com/docs/license/
     check-mark: icon:check[]

--- a/publish.yml
+++ b/publish.yml
@@ -7,7 +7,7 @@ site:
 content:
   sources:
   - url: ./
-    branches: ['1.10', '1.11', '1.12', '1.13', '1.14', '1.15']
+    branches: ['1.10', '1.11', '1.12', '1.13', '1.14', 'dev']
     exclude:
     - '!**/_includes/*'
     - '!**/readme.adoc'

--- a/publish.yml
+++ b/publish.yml
@@ -7,7 +7,7 @@ site:
 content:
   sources:
   - url: ./
-    branches: ['1.10', '1.11', '1.12', '1.13', '1.14', 'dev']
+    branches: ['1.10', '1.11', '1.12', '1.13', '1.14', '1.15']
     exclude:
     - '!**/_includes/*'
     - '!**/readme.adoc'


### PR DESCRIPTION

----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [ ] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!