### PR TITLE
Fix typos in Helm charts configuration section

### DIFF
--- a/modules/ROOT/pages/installation/kubernetes/helm-charts.adoc
+++ b/modules/ROOT/pages/installation/kubernetes/helm-charts.adoc
@@ -344,8 +344,9 @@ NOTE: The default username & password login can be disabled by setting `config.u
 
 === Configuration overrides
 
-You can now override arbitrary NOM server confgiuration with `vlaues.yaml` using the new `config.overrides` section
-to set overrides as enviroment values. For example:
+You can now override arbitrary NOM server configuration with `values.yaml` using the new `config.overrides` section to set overrides as environment values.
+For example:
+
 [source,yaml]
 ----
 config:


### PR DESCRIPTION
Corrected typos in the Helm charts documentation regarding configuration overrides.



----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [ ] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!