### PR TITLE
DOCOPS-176 Add page-tabs attributes to publish playbook

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -35,6 +35,8 @@ asciidoc:
     - "@neo4j-documentation/macros"
     - "@neo4j-antora/mark-terms"
   attributes:
+    page-tabs: tools@
+    page-tabs-index: 60
     page-theme: docs
     page-type: Docs
     page-search-type: Docs


### PR DESCRIPTION
Adds `page-tabs` and `page-tabs-index` to `publish.yml`:

```yaml
page-tabs: tools@
page-tabs-index: 60
```

Places this docset in the `tools` tab of the aggregated tabbed navigation, at the
position matching its order in the Docs menu on neo4j.com/docs. The value is
soft-set with a trailing `@` so it can be overridden.
