### PR TITLE
Adding docs for high-throughput deployment configuration options

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -90,6 +90,7 @@
 // ** xref:operation/backup-manager.adoc[]
 // ** xref:operation/performance-manager.adoc[]
 ** xref:operation/upgrade-manager.adoc[]
+** xref:operation/large-installations.adoc[]
 //** xref:operation/admin-manager.adoc[]
 
 // * Integration

--- a/modules/ROOT/pages/addition/agent-installation/agent-config-file.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/agent-config-file.adoc
@@ -30,3 +30,6 @@ token:
     clientId: "<agent client ID>"
     clientSecret: "<agent client secret>" 
 ----
+
+Instance-level query log options can also be expressed in the configuration file, for example the minimum query duration as `queryLogMinDuration: "50"`, which is the equivalent of the `CONFIG_INSTANCE_n_QUERY_LOG_MIN_DURATION` environment variable.
+For guidance on choosing a value in deployments with a high query throughput, see xref:/operation/large-installations.adoc#querylog-ingestion[Large installations].

--- a/modules/ROOT/pages/addition/agent-installation/manual.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/manual.adoc
@@ -301,11 +301,14 @@ If set, appends the appropriate log appender automatically (including the port s
 | /var/lib/neo4j/conf/server-logs.xml
 
 | `CONFIG_INSTANCE_1_QUERY_LOG_MIN_DURATION`
-| Minimum duration in milliseconds for a query to be logged (optional)
+| Minimum duration in milliseconds for a query to be logged.
+Only queries whose elapsed time is greater than or equal to this value are ingested.
+Default: `50`. Set to `0` to forward all queries. (optional)
 | 100
 
 | `CONFIG_INSTANCE_1_QUERY_LOG_MIN_DURATION_FILTER_ERRORS`
-| Enable filter for errors under the minimum duration in milliseconds (optional)
+| Enable filter for errors under the minimum duration in milliseconds.
+Queries that produced an error bypass the minimum duration filter, unless this is set to `true`. (optional)
 | true
 
 | `CONFIG_INSTANCE_1_QUERY_LOG_DISABLE_OBFUSCATION`
@@ -316,6 +319,11 @@ If set, appends the appropriate log appender automatically (including the port s
 | Collect and show queries coming from the NOM agent (optional)
 | true
 |===
+
+[NOTE]
+====
+For guidance on tuning query log ingestion in high-throughput deployments, including how to remediate query log buffer overflow warnings, see *xref:/operation/large-installations.adoc#querylog-ingestion[Large installations]*.
+====
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/addition/agent-installation/self-registered.adoc
+++ b/modules/ROOT/pages/addition/agent-installation/self-registered.adoc
@@ -347,11 +347,14 @@ If set, appends the appropriate log appender automatically (including the port s
 | /var/lib/neo4j/conf/server-logs.xml
 
 | `CONFIG_INSTANCE_1_QUERY_LOG_MIN_DURATION`
-| Minimum duration in milliseconds for a query to be logged (optional)
+| Minimum duration in milliseconds for a query to be logged.
+Only queries whose elapsed time is greater than or equal to this value are ingested.
+Default: `50`. Set to `0` to forward all queries. (optional)
 | 100
 
 | `CONFIG_INSTANCE_1_QUERY_LOG_MIN_DURATION_FILTER_ERRORS`
-| Enable filter for errors under the minimum duration in milliseconds (optional)
+| Enable filter for errors under the minimum duration in milliseconds.
+Queries that produced an error bypass the minimum duration filter, unless this is set to `true`. (optional)
 | true
 
 | `CONFIG_INSTANCE_1_QUERY_LOG_DISABLE_OBFUSCATION`
@@ -362,6 +365,11 @@ If set, appends the appropriate log appender automatically (including the port s
 | Collect and show queries coming from the NOM agent (optional)
 | true
 |===
+
+[NOTE]
+====
+For guidance on tuning query log ingestion in high-throughput deployments, including how to remediate query log buffer overflow warnings, see *xref:/operation/large-installations.adoc#querylog-ingestion[Large installations]*.
+====
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/installation/server.adoc
+++ b/modules/ROOT/pages/installation/server.adoc
@@ -359,9 +359,36 @@ For details about configuring proxy in Java, see link:https://docs.oracle.com/en
 | `LOGGING_LEVEL_COM_NEO4J_OPSMANAGER_SERVER_CONFIG`
 | Log level of the configuration logger. Setting it to `debug` is useful for troubleshooting SSO issues. Default: `info`. (optional)
 | `error`, `warn`, `info`, `debug` or `trace`
+
+| `metrics.aggregation.schedule`
+| `METRICS_AGGREGATION_SCHEDULE`
+| Cron expression that controls how often raw metric nodes are aggregated into hourly summaries. Default: `0 05 * * * *`. (optional)
+| `0 0/30 * * * *`
+
+| `metrics.aggregation.single-retention-time`
+| `METRICS_AGGREGATION_SINGLE_RETENTION_TIME`
+| ISO-8601 duration. Raw metric nodes older than this are eligible for aggregation. Default: `P3D`. (optional)
+| `P1D`
+
+| `metrics.cleanup.schedule`
+| `METRICS_CLEANUP_SCHEDULE`
+| Cron expression that controls how often aggregated metric nodes older than the retention time are deleted. Default: `0 0 2 * * *`. (optional)
+| `0 0 3 * * *`
+
+| `metrics.cleanup.retention-time`
+| `METRICS_CLEANUP_RETENTION_TIME`
+| ISO-8601 duration. Aggregated metric nodes older than this are deleted. Default: `P31D`. (optional)
+| `P14D`
+
+| `metrics.cleanup.batch-size`
+| `METRICS_CLEANUP_BATCH_SIZE`
+| Number of nodes deleted per transaction during cleanup. Default: `3000`. (optional)
+| 1000
 |===
 
 See xref:./sso/configuration.adoc[SSO Configuration] for SSO-related configuration options.
+
+See xref:../operation/large-installations.adoc#metrics-aggregation[Large installations] for guidance on tuning the metric aggregation and cleanup settings for high-throughput deployments.
 
 == Accessing Ops Manager
 

--- a/modules/ROOT/pages/introduction/resilience.adoc
+++ b/modules/ROOT/pages/introduction/resilience.adoc
@@ -45,6 +45,7 @@ The circuit breaker is automatically configured and cannot be disabled. If there
 [NOTE]
 ====
 Best practices dictate the use of a minimum duration filter which greatly cuts down on the volume of logs to be processed, while preserving queries of interest. The built-in obfuscation functionality also helps by reducing query text cardinality.
+For the minimum duration filter and its default value, see *xref:../operation/large-installations.adoc#querylog-min-duration[Limiting the query log volume with a minimum duration]*.
 ====
 
 == Data caching
@@ -75,3 +76,6 @@ The metrics buffer can be adjusted by changing the outgoing message buffer size 
 | The maximum number of outgoing messages to buffer (optional)
 | 200
 |===
+
+If the incoming query log buffer of the agent, or the corresponding buffer on the server side, overflows, warnings are written to the agent and server logs.
+These warnings and their remediation are described in *xref:../operation/large-installations.adoc#querylog-buffer-overflow[Query log buffer overflow warnings]*.

--- a/modules/ROOT/pages/monitoring/log-manager.adoc
+++ b/modules/ROOT/pages/monitoring/log-manager.adoc
@@ -16,7 +16,7 @@ image::logs.png[width=800]
 It is possible to view individual query executions under the **Details** tab, or by hovering over an aggregated query and clicking the arrow button that appears to the right.
 
 Individual queries are retained for 24 hours, after which they are aggregated into one-hour blocks. 
-You can still view information, such as average time to execute the query, and how many times it was executed within the time window. 
+You can still view information, such as the average time to execute the query and how many times it was executed within the time window.
 After 7 days, the queries are further aggregated into 24-hour blocks and retained for an additional 30 days.
 
 If the volume of ingested query logs is too high for your deployment, it can be reduced on the agent side, as described in *xref:../operation/large-installations.adoc#querylog-ingestion[Large installations]*.

--- a/modules/ROOT/pages/monitoring/log-manager.adoc
+++ b/modules/ROOT/pages/monitoring/log-manager.adoc
@@ -19,6 +19,8 @@ Individual queries are retained for 24 hours, after which they are aggregated in
 You can still view information, such as average time to execute the query, and how many times it was executed within the time window. 
 After 7 days, the queries are further aggregated into 24-hour blocks and retained for an additional 30 days.
 
+If the volume of ingested query logs is too high for your deployment, it can be reduced on the agent side, as described in *xref:../operation/large-installations.adoc#querylog-ingestion[Large installations]*.
+
 For more fine-grained filtering and custom time windows, use the **Request log** modal dialog.
 
 image::querylog-modal.png[width=800]

--- a/modules/ROOT/pages/monitoring/metric-manager.adoc
+++ b/modules/ROOT/pages/monitoring/metric-manager.adoc
@@ -6,7 +6,10 @@ The time window for displayed data can be switched on top left of the metrics pa
 
 [NOTE]
 ====
-To allow efficient metric storage, metrics data older than 3 days is aggregated to hourly summary.
+To allow efficient metric storage, per default the metrics data older than 3 days is aggregated to hourly summary, and the raw data points are then deleted.
+The aggregated data is retained for 31 days.
+Both retention windows, as well as the schedules of the aggregation and cleanup jobs, are configurable.
+For details, see *xref:../operation/large-installations.adoc#metrics-aggregation[Large installations]*.
 ====
 
 The "Show Resources" button in the *Host* tab and *Instance* tab shows a table with static data for managed DBMSs, like the number CPU cores of the system (physical and logical) and memory/disk capacities.

--- a/modules/ROOT/pages/monitoring/metric-manager.adoc
+++ b/modules/ROOT/pages/monitoring/metric-manager.adoc
@@ -6,7 +6,7 @@ The time window for displayed data can be switched on top left of the metrics pa
 
 [NOTE]
 ====
-To allow efficient metric storage, per default the metrics data older than 3 days is aggregated to hourly summary, and the raw data points are then deleted.
+To allow efficient metric storage, by default the metrics data older than 3 days is aggregated to hourly summary, and the raw data points are then deleted.
 The aggregated data is retained for 31 days.
 Both retention windows, as well as the schedules of the aggregation and cleanup jobs, are configurable.
 For details, see *xref:../operation/large-installations.adoc#metrics-aggregation[Large installations]*.

--- a/modules/ROOT/pages/operation/large-installations.adoc
+++ b/modules/ROOT/pages/operation/large-installations.adoc
@@ -82,8 +82,9 @@ The server-side protection against query log overload is described in xref:intro
 
 === Query log retention
 
-Individual query executions older than 30 days are deleted from the NOM persistence database automatically.
-Aggregated query statistics, which are rolled up per query fingerprint per day, are retained for an additional 30 days after the individual executions are removed.
+Individual queries are retained for 24 hours, after which they are aggregated into one-hour blocks.
+You can still view information, such as the average time to execute the query and how many times it was executed within the time window.
+After 7 days, the queries are further aggregated into 24-hour blocks and retained for an additional 30 days.
 
 For more information about how query logs are presented and aggregated, see xref:monitoring/log-manager.adoc[Log manager].
 

--- a/modules/ROOT/pages/operation/large-installations.adoc
+++ b/modules/ROOT/pages/operation/large-installations.adoc
@@ -80,6 +80,16 @@ QueryLogReceiverService buffer overflow (N/128) - dropping message. Consider inc
 In both cases, the recommended remediation is to raise `CONFIG_INSTANCE_N_QUERY_LOG_MIN_DURATION` on the agent, as described in <<querylog-min-duration,Limiting the query log volume with a minimum duration>>.
 The server-side protection against query log overload is described in xref:introduction/resilience.adoc[Resilience].
 
+[NOTE]
+====
+Older versions of NOM might only tell you when the buffer overflow happens with a message like this:
+
+[source, role=noheader]
+----
+QueryLogReceiverService buffer overflow - dropping message
+----
+====
+
 === Query log retention
 
 Individual queries are retained for 24 hours, after which they are aggregated into one-hour blocks.

--- a/modules/ROOT/pages/operation/large-installations.adoc
+++ b/modules/ROOT/pages/operation/large-installations.adoc
@@ -1,0 +1,165 @@
+= Large installations
+:description: This section describes the configuration options that are relevant when running Neo4j Ops Manager with Neo4j deployments that have a high query or metric throughput.
+
+NOM agents and NOM server are designed to cope with the load of a typical Neo4j deployment without any additional configuration.
+This section documents the configuration options that are relevant when running NOM against Neo4j deployments with a high query or metric throughput.
+
+All of the settings described here are optional.
+The defaults are safe for typical deployments and only need to be adjusted when you observe signs of overload, such as buffer overflow warnings in the server or agent logs, or a NOM persistence database that grows rapidly.
+
+[[querylog-ingestion]]
+== Query log ingestion
+
+NOM agents listen on a local TCP port for Neo4j query log events and forward them in batches to NOM server, which writes them to the NOM persistence database.
+Under high query load, either the incoming buffer of the agent or the server-side processing queue can overflow.
+
+[[querylog-min-duration]]
+=== Limiting the query log volume with a minimum duration
+
+The most effective lever for controlling the query log volume is the minimum duration filter, `CONFIG_INSTANCE_N_QUERY_LOG_MIN_DURATION`.
+Only queries whose elapsed time is greater than or equal to this value, in milliseconds, are ingested.
+
+* The default is `50` ms, which means that queries shorter than 50 ms are discarded by the agent before they are forwarded.
+* Setting the value to `0` means that all queries are forwarded, without any filtering.
+* A good starting point for high-load environments is `100` ms.
+Lower the threshold gradually once you have confirmed that NOM server can keep up.
+* Errors, that is, queries that produced a failure reason in the Neo4j query log, bypass the duration filter by default, so they are always ingested regardless of their elapsed time.
+To filter errors by duration as well, set `CONFIG_INSTANCE_N_QUERY_LOG_MIN_DURATION_FILTER_ERRORS` to `true`.
+
+The minimum duration can be set in either of the following ways:
+
+[cols="<,<",options="header"]
+|===
+| Where set
+| How to set
+
+| Agent environment variable
+| `CONFIG_INSTANCE_1_QUERY_LOG_MIN_DURATION=50`
+
+| Agent configuration file
+| `queryLogMinDuration: "50"`
+|===
+
+For the complete list of agent query log variables, see xref:addition/agent-installation/manual.adoc#querylog[Query log collection configuration].
+For the agent configuration file, see xref:addition/agent-installation/agent-config-file.adoc[Agent configuration file].
+
+[TIP]
+====
+*Use parameterized queries.*
+If a workload issues many structurally identical queries with different literal values, for example `MATCH (n) WHERE n.id = 42`, switching to parameterized queries, for example `MATCH (n) WHERE n.id = $id`, reduces the number of distinct query log entries that NOM needs to store, and makes the aggregated statistics more meaningful.
+====
+
+[[querylog-buffer-overflow]]
+=== Query log buffer overflow warnings
+
+When the incoming message buffer of the agent reaches 80% of its capacity, that is `13107` of `16384` slots, the agent emits a `WARN` level log entry:
+
+[source, role=noheader]
+----
+Query log message buffer is nearly full (N/16384). Consider increasing CONFIG_INSTANCE_N_QUERY_LOG_MIN_DURATION to reduce ingestion rate.
+----
+
+When the buffer is completely full, the agent drops the incoming message and enters a 60-second cooldown, during which all further messages are discarded.
+An agent event, `FAILED_QUERYLOG_INCOMING_OVERFLOW`, is also raised and is visible in the NOM UI.
+
+On the NOM server side, a similar buffer of `128` pending message batches exists.
+When it reaches 80% of its capacity, that is `102` batches or more, NOM server logs:
+
+[source, role=noheader]
+----
+QueryLogReceiverService buffer is nearly full (N/128)! Consider increasing CONFIG_INSTANCE_N_QUERY_LOG_MIN_DURATION on the agent to reduce query log ingestion rate.
+----
+
+When the buffer is full, that is `128` batches or more, the incoming batches from that agent are dropped:
+
+[source, role=noheader]
+----
+QueryLogReceiverService buffer overflow (N/128) - dropping message. Consider increasing CONFIG_INSTANCE_N_QUERY_LOG_MIN_DURATION on the agent to reduce query log ingestion rate.
+----
+
+In both cases, the recommended remediation is to raise `CONFIG_INSTANCE_N_QUERY_LOG_MIN_DURATION` on the agent, as described in <<querylog-min-duration,Limiting the query log volume with a minimum duration>>.
+The server-side protection against query log overload is described in xref:introduction/resilience.adoc[Resilience].
+
+=== Query log retention
+
+Individual query executions older than 30 days are deleted from the NOM persistence database automatically.
+Aggregated query statistics, which are rolled up per query fingerprint per day, are retained for an additional 30 days after the individual executions are removed.
+
+For more information about how query logs are presented and aggregated, see xref:monitoring/log-manager.adoc[Log manager].
+
+[[metrics-aggregation]]
+== Metrics aggregation and cleanup
+
+Raw metric data points emitted by the monitored Neo4j instances are stored as individual `:Metric` nodes in the NOM persistence database.
+To prevent unbounded growth, NOM periodically aggregates them into hourly `:Metric:Aggregate` nodes and then deletes the raw nodes.
+
+=== How aggregation works
+
+* Aggregation runs on a cron schedule, by default five minutes past every hour (`0 05 * * * *`).
+* Raw metric nodes are retained for three days (`P3D`) after they are written.
+Once a metric node is older than three days, the next aggregation run includes it in the hourly rollup and then deletes the original.
+* The resulting `:Metric:Aggregate` nodes are retained for 31 days (`P31D`).
+A separate cleanup job, running daily at 02:00 (`0 0 2 * * *`), deletes the aggregate nodes that are older than this window.
+
+For a description of how the aggregated metrics are presented, see xref:monitoring/metric-manager.adoc[Metric manager].
+
+=== Aggregation and cleanup configuration reference
+
+All of the schedules and retention windows above are configurable through NOM server properties.
+They can be set in `application.properties`, as environment variables, or as command line arguments to `java -jar server.jar`, in the same way as any other server property.
+See xref:installation/server.adoc#config_ref[Server configuration reference].
+
+[cols="<,<,<,<",options="header"]
+|===
+| Property
+| Environment variable
+| Default
+| Description
+
+| `metrics.aggregation.schedule`
+| `METRICS_AGGREGATION_SCHEDULE`
+| `0 05 * * * *`
+| Cron expression that controls how often the hourly aggregation runs.
+
+| `metrics.aggregation.single-retention-time`
+| `METRICS_AGGREGATION_SINGLE_RETENTION_TIME`
+| `P3D`
+| ISO-8601 duration. Raw metric nodes older than this are eligible for aggregation.
+
+| `metrics.cleanup.schedule`
+| `METRICS_CLEANUP_SCHEDULE`
+| `0 0 2 * * *`
+| Cron expression that controls how often the deletion of old aggregate nodes runs.
+
+| `metrics.cleanup.retention-time`
+| `METRICS_CLEANUP_RETENTION_TIME`
+| `P31D`
+| ISO-8601 duration. Aggregated metric nodes older than this are deleted.
+
+| `metrics.cleanup.batch-size`
+| `METRICS_CLEANUP_BATCH_SIZE`
+| `3000`
+| Number of nodes deleted per transaction during cleanup.
+|===
+
+The following example passes overrides as Java arguments:
+
+[source, terminal, role=noheader]
+----
+java -jar server.jar \
+  --metrics.cleanup.retention-time=P14D \
+  --metrics.aggregation.single-retention-time=P1D \
+  --metrics.aggregation.schedule="0 0/30 * * * *"
+----
+
+=== Tuning guidance for large deployments
+
+* If you observe that the NOM persistence database grows rapidly, consider reducing `metrics.cleanup.retention-time`, for example to `P14D`, and `metrics.aggregation.single-retention-time`, for example to `P1D`, to keep the number of raw and aggregate nodes lower.
+* If individual cleanup transactions are too large and cause contention, reduce `metrics.cleanup.batch-size`, for example to `1000`.
+This makes each transaction smaller, at the cost of more round trips.
+* Running aggregation more frequently, for example every 30 minutes with `0 0/30 * * * *`, reduces the number of raw nodes that accumulate between runs, which in turn makes each aggregation pass faster.
+
+[NOTE]
+====
+Cron expressions follow the Spring Framework six-field format: `seconds minutes hours day-of-month month day-of-week`.
+====


### PR DESCRIPTION
Requires https://github.com/neo-technology/neo4j-ops-manager-backend/pull/2373 and a new release

Part of NOM-223

----

If you open a PR that needs to go into a current version, you need to *cherry-pick your commit from dev over to the current version branch*. Only then will the proper builds that generate html/pdf be run. But beware: Docs will be generated but not published automatically!

- [x] N/A - or - I have added the appropriate "cherry-pick-to" labels to this PR so I don't forget to do this later!